### PR TITLE
Grid followup tweaks

### DIFF
--- a/components/css_spacing_utilities/README.md
+++ b/components/css_spacing_utilities/README.md
@@ -1,21 +1,5 @@
 Spacing utilities and SASS variables allow you to quickly set an element's margin or padding to defined values that align with the Phenotypes modular scale. 
 
-### SASS variables
-
-| Sass variable | Space |
-| -------- | ----- |
-| `$spacer-0` | 0 |
-| `$spacer-1` | 5px |
-| `$spacer-2` | 7px |
-| `$spacer-3` | 11px |
-| `$spacer-4` | 16px |
-| `$spacer-5` | 24px |
-| `$spacer-6` | 36px |
-| `$spacer-7` | 53px |
-| `$spacer-8` | 79px |
-| `$spacer-9` | 119px |
-
-
 ### Responsive classes
 
 Responsive class utilities are provided for as well, following this format:
@@ -31,12 +15,33 @@ Responsive class utilities are provided for as well, following this format:
 	* omitted for all sides
 * `size` is a number from 0 to 9 (corresponding to the variables above)
 * `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
-* Margin auto values are supported and follow the same syntax (e.g. `.mx-auto-md`)
+
+Special cases:
+
+* Margin auto values follow the pattern `.m[x,y]-auto-[breakpoint]`
+* Negative spacing helpers for x-axis: `.mxn[size]-[breakpoint]`
 
 Examples:
 
 * `.mb4.mb5-md` adds 16px `margin-bottom` for `xs` up, and 24px for `md` up
 * `.py1` adds 5px `padding-top` and `padding-bottom`
+
+
+### SASS variables
+
+| Sass variable | Space |
+| -------- | ----- |
+| `$spacer-0` | 0 |
+| `$spacer-1` | 5px |
+| `$spacer-2` | 7px |
+| `$spacer-3` | 11px |
+| `$spacer-4` | 16px |
+| `$spacer-5` | 24px |
+| `$spacer-6` | 36px |
+| `$spacer-7` | 53px |
+| `$spacer-8` | 79px |
+| `$spacer-9` | 119px |
+
 
 ### Etc.
 

--- a/components/grid/grid.jsx
+++ b/components/grid/grid.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 function GridExamples() {
   return (
-    <div className="grid-examples">
+    <div>
       <div className="container">
         <p>
           <strong>Responsive:</strong> add multiple classes with responsive suffixes to
@@ -10,11 +10,21 @@ function GridExamples() {
         </p>
 
         <div className="row">
-          <div className="col-4 col-2-md">.col-4.col-2-md</div>
-          <div className="col-4 col-8-md">
-            Resize me! I'm wider when the screen is wider.<br />.col-4.col-8-md
+          <div className="col-4 col-2-md">
+            <div className="grid-example-content">
+              .col-4.col-2-md
+            </div>
           </div>
-          <div className="col-4 col-2-md">.col-4.col-2-md</div>
+          <div className="col-4 col-8-md">
+            <div className="grid-example-content">
+              Resize me! I’m wider when the screen is wider.<br />.col-4.col-8-md
+            </div>
+          </div>
+          <div className="col-4 col-2-md">
+            <div className="grid-example-content">
+              .col-4.col-2-md
+            </div>
+          </div>
         </div>
 
         <hr />
@@ -22,7 +32,9 @@ function GridExamples() {
         <p><strong>Offsets</strong></p>
 
         <div className="row">
-          <div className="col-6 offset-3">.col-6.offset-3</div>
+          <div className="col-6 offset-3">
+            <div className="grid-example-content">.col-6.offset-3</div>
+          </div>
         </div>
 
         <hr />
@@ -30,13 +42,28 @@ function GridExamples() {
         <p>
           <strong>Custom gutter spacing</strong>:
           customize gutter widths by adding <code>.no-gutters</code> to
-          your <code>.row</code> class, and then using spacing helpers on the <code>.col-*</code> classes.
+          your <code>.row</code> class, and then using <code>.px*</code> padding helpers on the <code>.col-*</code> classes.
+        </p>
+        <p>
+          You’ll also need to add a corresponding negative <code>.mxn*</code> margin class on the <code>.row</code> to get rid of the extra padding on the sides.
         </p>
 
-        <div className="row no-gutters">
-          <div className="col-4 px6">.col-4.px6</div>
-          <div className="col-4 px6">.col-4.px6</div>
-          <div className="col-4 px6">.col-4.px6</div>
+        <div className="row no-gutters mxn1">
+          <div className="col-4 px1">
+            <div className="grid-example-content">
+              .col-4.px1
+            </div>
+          </div>
+          <div className="col-4 px1">
+            <div className="grid-example-content">
+              .col-4.px1
+            </div>
+          </div>
+          <div className="col-4 px1">
+            <div className="grid-example-content">
+              .col-4.px1
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/components/message/_message.scss
+++ b/components/message/_message.scss
@@ -1,6 +1,7 @@
 // scss-lint:disable SelectorFormat
 
 .Message {
+  background-color: $gray-200;
   border-radius: $border-radius;
   padding: $spacer;
 }

--- a/fractal_assets/css/preview.css
+++ b/fractal_assets/css/preview.css
@@ -6,9 +6,7 @@
  * CSS for styling demos and examples in fractal
  */
 
-.grid-examples .col,
-.grid-examples [class^=col-]
-{
+.grid-example-content {
   color: #fff;
   padding-top: 1rem;
   padding-bottom: 1rem;

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -216,10 +216,11 @@ $grid-breakpoints: (
 // ------------------------------
 
 $container-max-widths: (
-  sm: 540px,
-  md: 720px,
-  lg: 960px,
-  xl: 1140px
+  xs: 451px,
+  sm: 673px,
+  md: 879px,
+  lg: 1148px,
+  xl: 1148px
 ) !default;
 
 $grid-columns:               12 !default;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1903,6 +1903,10 @@ hr {
   margin-right: 0 !important;
   margin-left: 0 !important; }
 
+.mxn0 {
+  margin-right: 0 !important;
+  margin-left: 0 !important; }
+
 .my0 {
   margin-top: 0 !important;
   margin-bottom: 0 !important; }
@@ -1925,6 +1929,10 @@ hr {
 .mx1 {
   margin-right: 5px !important;
   margin-left: 5px !important; }
+
+.mxn1 {
+  margin-right: -5px !important;
+  margin-left: -5px !important; }
 
 .my1 {
   margin-top: 5px !important;
@@ -1949,6 +1957,10 @@ hr {
   margin-right: 7px !important;
   margin-left: 7px !important; }
 
+.mxn2 {
+  margin-right: -7px !important;
+  margin-left: -7px !important; }
+
 .my2 {
   margin-top: 7px !important;
   margin-bottom: 7px !important; }
@@ -1971,6 +1983,10 @@ hr {
 .mx3 {
   margin-right: 11px !important;
   margin-left: 11px !important; }
+
+.mxn3 {
+  margin-right: -11px !important;
+  margin-left: -11px !important; }
 
 .my3 {
   margin-top: 11px !important;
@@ -1995,6 +2011,10 @@ hr {
   margin-right: 16px !important;
   margin-left: 16px !important; }
 
+.mxn4 {
+  margin-right: -16px !important;
+  margin-left: -16px !important; }
+
 .my4 {
   margin-top: 16px !important;
   margin-bottom: 16px !important; }
@@ -2017,6 +2037,10 @@ hr {
 .mx5 {
   margin-right: 24px !important;
   margin-left: 24px !important; }
+
+.mxn5 {
+  margin-right: -24px !important;
+  margin-left: -24px !important; }
 
 .my5 {
   margin-top: 24px !important;
@@ -2041,6 +2065,10 @@ hr {
   margin-right: 36px !important;
   margin-left: 36px !important; }
 
+.mxn6 {
+  margin-right: -36px !important;
+  margin-left: -36px !important; }
+
 .my6 {
   margin-top: 36px !important;
   margin-bottom: 36px !important; }
@@ -2063,6 +2091,10 @@ hr {
 .mx7 {
   margin-right: 53px !important;
   margin-left: 53px !important; }
+
+.mxn7 {
+  margin-right: -53px !important;
+  margin-left: -53px !important; }
 
 .my7 {
   margin-top: 53px !important;
@@ -2087,6 +2119,10 @@ hr {
   margin-right: 79px !important;
   margin-left: 79px !important; }
 
+.mxn8 {
+  margin-right: -79px !important;
+  margin-left: -79px !important; }
+
 .my8 {
   margin-top: 79px !important;
   margin-bottom: 79px !important; }
@@ -2109,6 +2145,10 @@ hr {
 .mx9 {
   margin-right: 119px !important;
   margin-left: 119px !important; }
+
+.mxn9 {
+  margin-right: -119px !important;
+  margin-left: -119px !important; }
 
 .my9 {
   margin-top: 119px !important;
@@ -2381,6 +2421,9 @@ hr {
   .mx0-sm {
     margin-right: 0 !important;
     margin-left: 0 !important; }
+  .mxn0-sm {
+    margin-right: 0 !important;
+    margin-left: 0 !important; }
   .my0-sm {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -2397,6 +2440,9 @@ hr {
   .mx1-sm {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mxn1-sm {
+    margin-right: -5px !important;
+    margin-left: -5px !important; }
   .my1-sm {
     margin-top: 5px !important;
     margin-bottom: 5px !important; }
@@ -2413,6 +2459,9 @@ hr {
   .mx2-sm {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mxn2-sm {
+    margin-right: -7px !important;
+    margin-left: -7px !important; }
   .my2-sm {
     margin-top: 7px !important;
     margin-bottom: 7px !important; }
@@ -2429,6 +2478,9 @@ hr {
   .mx3-sm {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mxn3-sm {
+    margin-right: -11px !important;
+    margin-left: -11px !important; }
   .my3-sm {
     margin-top: 11px !important;
     margin-bottom: 11px !important; }
@@ -2445,6 +2497,9 @@ hr {
   .mx4-sm {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mxn4-sm {
+    margin-right: -16px !important;
+    margin-left: -16px !important; }
   .my4-sm {
     margin-top: 16px !important;
     margin-bottom: 16px !important; }
@@ -2461,6 +2516,9 @@ hr {
   .mx5-sm {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mxn5-sm {
+    margin-right: -24px !important;
+    margin-left: -24px !important; }
   .my5-sm {
     margin-top: 24px !important;
     margin-bottom: 24px !important; }
@@ -2477,6 +2535,9 @@ hr {
   .mx6-sm {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mxn6-sm {
+    margin-right: -36px !important;
+    margin-left: -36px !important; }
   .my6-sm {
     margin-top: 36px !important;
     margin-bottom: 36px !important; }
@@ -2493,6 +2554,9 @@ hr {
   .mx7-sm {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mxn7-sm {
+    margin-right: -53px !important;
+    margin-left: -53px !important; }
   .my7-sm {
     margin-top: 53px !important;
     margin-bottom: 53px !important; }
@@ -2509,6 +2573,9 @@ hr {
   .mx8-sm {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mxn8-sm {
+    margin-right: -79px !important;
+    margin-left: -79px !important; }
   .my8-sm {
     margin-top: 79px !important;
     margin-bottom: 79px !important; }
@@ -2525,6 +2592,9 @@ hr {
   .mx9-sm {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mxn9-sm {
+    margin-right: -119px !important;
+    margin-left: -119px !important; }
   .my9-sm {
     margin-top: 119px !important;
     margin-bottom: 119px !important; }
@@ -2719,6 +2789,9 @@ hr {
   .mx0-md {
     margin-right: 0 !important;
     margin-left: 0 !important; }
+  .mxn0-md {
+    margin-right: 0 !important;
+    margin-left: 0 !important; }
   .my0-md {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -2735,6 +2808,9 @@ hr {
   .mx1-md {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mxn1-md {
+    margin-right: -5px !important;
+    margin-left: -5px !important; }
   .my1-md {
     margin-top: 5px !important;
     margin-bottom: 5px !important; }
@@ -2751,6 +2827,9 @@ hr {
   .mx2-md {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mxn2-md {
+    margin-right: -7px !important;
+    margin-left: -7px !important; }
   .my2-md {
     margin-top: 7px !important;
     margin-bottom: 7px !important; }
@@ -2767,6 +2846,9 @@ hr {
   .mx3-md {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mxn3-md {
+    margin-right: -11px !important;
+    margin-left: -11px !important; }
   .my3-md {
     margin-top: 11px !important;
     margin-bottom: 11px !important; }
@@ -2783,6 +2865,9 @@ hr {
   .mx4-md {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mxn4-md {
+    margin-right: -16px !important;
+    margin-left: -16px !important; }
   .my4-md {
     margin-top: 16px !important;
     margin-bottom: 16px !important; }
@@ -2799,6 +2884,9 @@ hr {
   .mx5-md {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mxn5-md {
+    margin-right: -24px !important;
+    margin-left: -24px !important; }
   .my5-md {
     margin-top: 24px !important;
     margin-bottom: 24px !important; }
@@ -2815,6 +2903,9 @@ hr {
   .mx6-md {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mxn6-md {
+    margin-right: -36px !important;
+    margin-left: -36px !important; }
   .my6-md {
     margin-top: 36px !important;
     margin-bottom: 36px !important; }
@@ -2831,6 +2922,9 @@ hr {
   .mx7-md {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mxn7-md {
+    margin-right: -53px !important;
+    margin-left: -53px !important; }
   .my7-md {
     margin-top: 53px !important;
     margin-bottom: 53px !important; }
@@ -2847,6 +2941,9 @@ hr {
   .mx8-md {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mxn8-md {
+    margin-right: -79px !important;
+    margin-left: -79px !important; }
   .my8-md {
     margin-top: 79px !important;
     margin-bottom: 79px !important; }
@@ -2863,6 +2960,9 @@ hr {
   .mx9-md {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mxn9-md {
+    margin-right: -119px !important;
+    margin-left: -119px !important; }
   .my9-md {
     margin-top: 119px !important;
     margin-bottom: 119px !important; }
@@ -3057,6 +3157,9 @@ hr {
   .mx0-lg {
     margin-right: 0 !important;
     margin-left: 0 !important; }
+  .mxn0-lg {
+    margin-right: 0 !important;
+    margin-left: 0 !important; }
   .my0-lg {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -3073,6 +3176,9 @@ hr {
   .mx1-lg {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mxn1-lg {
+    margin-right: -5px !important;
+    margin-left: -5px !important; }
   .my1-lg {
     margin-top: 5px !important;
     margin-bottom: 5px !important; }
@@ -3089,6 +3195,9 @@ hr {
   .mx2-lg {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mxn2-lg {
+    margin-right: -7px !important;
+    margin-left: -7px !important; }
   .my2-lg {
     margin-top: 7px !important;
     margin-bottom: 7px !important; }
@@ -3105,6 +3214,9 @@ hr {
   .mx3-lg {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mxn3-lg {
+    margin-right: -11px !important;
+    margin-left: -11px !important; }
   .my3-lg {
     margin-top: 11px !important;
     margin-bottom: 11px !important; }
@@ -3121,6 +3233,9 @@ hr {
   .mx4-lg {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mxn4-lg {
+    margin-right: -16px !important;
+    margin-left: -16px !important; }
   .my4-lg {
     margin-top: 16px !important;
     margin-bottom: 16px !important; }
@@ -3137,6 +3252,9 @@ hr {
   .mx5-lg {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mxn5-lg {
+    margin-right: -24px !important;
+    margin-left: -24px !important; }
   .my5-lg {
     margin-top: 24px !important;
     margin-bottom: 24px !important; }
@@ -3153,6 +3271,9 @@ hr {
   .mx6-lg {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mxn6-lg {
+    margin-right: -36px !important;
+    margin-left: -36px !important; }
   .my6-lg {
     margin-top: 36px !important;
     margin-bottom: 36px !important; }
@@ -3169,6 +3290,9 @@ hr {
   .mx7-lg {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mxn7-lg {
+    margin-right: -53px !important;
+    margin-left: -53px !important; }
   .my7-lg {
     margin-top: 53px !important;
     margin-bottom: 53px !important; }
@@ -3185,6 +3309,9 @@ hr {
   .mx8-lg {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mxn8-lg {
+    margin-right: -79px !important;
+    margin-left: -79px !important; }
   .my8-lg {
     margin-top: 79px !important;
     margin-bottom: 79px !important; }
@@ -3201,6 +3328,9 @@ hr {
   .mx9-lg {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mxn9-lg {
+    margin-right: -119px !important;
+    margin-left: -119px !important; }
   .my9-lg {
     margin-top: 119px !important;
     margin-bottom: 119px !important; }
@@ -3395,6 +3525,9 @@ hr {
   .mx0-xl {
     margin-right: 0 !important;
     margin-left: 0 !important; }
+  .mxn0-xl {
+    margin-right: 0 !important;
+    margin-left: 0 !important; }
   .my0-xl {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -3411,6 +3544,9 @@ hr {
   .mx1-xl {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mxn1-xl {
+    margin-right: -5px !important;
+    margin-left: -5px !important; }
   .my1-xl {
     margin-top: 5px !important;
     margin-bottom: 5px !important; }
@@ -3427,6 +3563,9 @@ hr {
   .mx2-xl {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mxn2-xl {
+    margin-right: -7px !important;
+    margin-left: -7px !important; }
   .my2-xl {
     margin-top: 7px !important;
     margin-bottom: 7px !important; }
@@ -3443,6 +3582,9 @@ hr {
   .mx3-xl {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mxn3-xl {
+    margin-right: -11px !important;
+    margin-left: -11px !important; }
   .my3-xl {
     margin-top: 11px !important;
     margin-bottom: 11px !important; }
@@ -3459,6 +3601,9 @@ hr {
   .mx4-xl {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mxn4-xl {
+    margin-right: -16px !important;
+    margin-left: -16px !important; }
   .my4-xl {
     margin-top: 16px !important;
     margin-bottom: 16px !important; }
@@ -3475,6 +3620,9 @@ hr {
   .mx5-xl {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mxn5-xl {
+    margin-right: -24px !important;
+    margin-left: -24px !important; }
   .my5-xl {
     margin-top: 24px !important;
     margin-bottom: 24px !important; }
@@ -3491,6 +3639,9 @@ hr {
   .mx6-xl {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mxn6-xl {
+    margin-right: -36px !important;
+    margin-left: -36px !important; }
   .my6-xl {
     margin-top: 36px !important;
     margin-bottom: 36px !important; }
@@ -3507,6 +3658,9 @@ hr {
   .mx7-xl {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mxn7-xl {
+    margin-right: -53px !important;
+    margin-left: -53px !important; }
   .my7-xl {
     margin-top: 53px !important;
     margin-bottom: 53px !important; }
@@ -3523,6 +3677,9 @@ hr {
   .mx8-xl {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mxn8-xl {
+    margin-right: -79px !important;
+    margin-left: -79px !important; }
   .my8-xl {
     margin-top: 79px !important;
     margin-bottom: 79px !important; }
@@ -3539,6 +3696,9 @@ hr {
   .mx9-xl {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mxn9-xl {
+    margin-right: -119px !important;
+    margin-left: -119px !important; }
   .my9-xl {
     margin-top: 119px !important;
     margin-bottom: 119px !important; }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -167,18 +167,21 @@ a {
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
-  a:hover {
-    color: #008ab3;
-    text-decoration: underline; }
+
+a:hover {
+  color: #008ab3;
+  text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
   color: inherit;
   text-decoration: none; }
-  a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-    color: inherit;
-    text-decoration: none; }
-  a:not([href]):not([tabindex]):focus {
-    outline: 0; }
+
+a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
+  color: inherit;
+  text-decoration: none; }
+
+a:not([href]):not([tabindex]):focus {
+  outline: 0; }
 
 pre,
 code,
@@ -442,90 +445,107 @@ hr {
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 600px) {
-    .container {
-      width: 540px;
-      max-width: 100%; } }
-  @media (min-width: 900px) {
-    .container {
-      width: 720px;
-      max-width: 100%; } }
-  @media (min-width: 1200px) {
-    .container {
-      width: 960px;
-      max-width: 100%; } }
-  @media (min-width: 1500px) {
-    .container {
-      width: 1140px;
-      max-width: 100%; } }
+
+@media (min-width: 600px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container {
+    width: 540px;
+    max-width: 100%; } }
+
+@media (min-width: 900px) {
+  .container {
+    width: 720px;
+    max-width: 100%; } }
+
+@media (min-width: 1200px) {
+  .container {
+    width: 960px;
+    max-width: 100%; } }
+
+@media (min-width: 1500px) {
+  .container {
+    width: 1140px;
+    max-width: 100%; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
 
 .row {
   display: flex;
   flex-wrap: wrap;
   margin-right: -12px;
   margin-left: -12px; }
-  @media (min-width: 600px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 900px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 1200px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 1500px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
+
+@media (min-width: 600px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 900px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1200px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1500px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
 
 .no-gutters {
   margin-right: 0;
   margin-left: 0; }
-  .no-gutters > .col,
-  .no-gutters > [class*="col-"] {
-    padding-right: 0;
-    padding-left: 0; }
+
+.no-gutters > .col,
+.no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }
 
 .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
   position: relative;
@@ -533,22 +553,26 @@ hr {
   min-height: 1px;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
 
 .col {
   flex-basis: 0;
@@ -1203,6 +1227,7 @@ hr {
     margin-left: 91.66667%; } }
 
 .Message {
+  background-color: #eee;
   border-radius: 3px;
   padding: 16px; }
 
@@ -1223,8 +1248,9 @@ hr {
   border: 2px solid #dbdbdb;
   border-radius: 3px;
   width: 100%; }
-  .TextInput::placeholder {
-    color: rgba(0, 0, 0, 0.41); }
+
+.TextInput::placeholder {
+  color: rgba(0, 0, 0, 0.41); }
 
 .TextInput--is-disabled {
   background: #eee; }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -444,7 +444,9 @@ hr {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
-  padding-left: 12px; }
+  padding-left: 12px;
+  width: 451px;
+  max-width: 100%; }
 
 @media (min-width: 600px) {
   .container {
@@ -468,22 +470,22 @@ hr {
 
 @media (min-width: 600px) {
   .container {
-    width: 540px;
+    width: 673px;
     max-width: 100%; } }
 
 @media (min-width: 900px) {
   .container {
-    width: 720px;
+    width: 879px;
     max-width: 100%; } }
 
 @media (min-width: 1200px) {
   .container {
-    width: 960px;
+    width: 1148px;
     max-width: 100%; } }
 
 @media (min-width: 1500px) {
   .container {
-    width: 1140px;
+    width: 1148px;
     max-width: 100%; } }
 
 .container-fluid {

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -167,21 +167,18 @@ a {
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
-
-a:hover {
-  color: #008ab3;
-  text-decoration: underline; }
+  a:hover {
+    color: #008ab3;
+    text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
   color: inherit;
   text-decoration: none; }
-
-a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-  color: inherit;
-  text-decoration: none; }
-
-a:not([href]):not([tabindex]):focus {
-  outline: 0; }
+  a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
+    color: inherit;
+    text-decoration: none; }
+  a:not([href]):not([tabindex]):focus {
+    outline: 0; }
 
 pre,
 code,
@@ -445,107 +442,90 @@ hr {
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 600px) {
-  .container {
-    width: 540px;
-    max-width: 100%; } }
-
-@media (min-width: 900px) {
-  .container {
-    width: 720px;
-    max-width: 100%; } }
-
-@media (min-width: 1200px) {
-  .container {
-    width: 960px;
-    max-width: 100%; } }
-
-@media (min-width: 1500px) {
-  .container {
-    width: 1140px;
-    max-width: 100%; } }
+  @media (min-width: 600px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .container {
+      width: 540px;
+      max-width: 100%; } }
+  @media (min-width: 900px) {
+    .container {
+      width: 720px;
+      max-width: 100%; } }
+  @media (min-width: 1200px) {
+    .container {
+      width: 960px;
+      max-width: 100%; } }
+  @media (min-width: 1500px) {
+    .container {
+      width: 1140px;
+      max-width: 100%; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
 
 .row {
   display: flex;
   flex-wrap: wrap;
   margin-right: -12px;
   margin-left: -12px; }
-
-@media (min-width: 600px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 900px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1200px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1500px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
+  @media (min-width: 600px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 900px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 1200px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 1500px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
 
 .no-gutters {
   margin-right: 0;
   margin-left: 0; }
-
-.no-gutters > .col,
-.no-gutters > [class*="col-"] {
-  padding-right: 0;
-  padding-left: 0; }
+  .no-gutters > .col,
+  .no-gutters > [class*="col-"] {
+    padding-right: 0;
+    padding-left: 0; }
 
 .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
   position: relative;
@@ -553,26 +533,22 @@ hr {
   min-height: 1px;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
 
 .col {
   flex-basis: 0;
@@ -1247,9 +1223,8 @@ hr {
   border: 2px solid #dbdbdb;
   border-radius: 3px;
   width: 100%; }
-
-.TextInput::placeholder {
-  color: rgba(0, 0, 0, 0.41); }
+  .TextInput::placeholder {
+    color: rgba(0, 0, 0, 0.41); }
 
 .TextInput--is-disabled {
   background: #eee; }

--- a/styles/utilities/_spacing.scss
+++ b/styles/utilities/_spacing.scss
@@ -5,24 +5,6 @@
 // Based on Bootstrap 4
 // https://github.com/twbs/bootstrap/blob/v4-dev/scss/utilities/_spacing.scss
 //
-// Class names follow this format:
-//
-// [direction][sides][size]-[breakpoint]
-//
-// - Direction is (m, p) for margin/padding
-// - Sides (optional) is one of:
-//    * (t, b, l, r) for top/bottom/left/right
-//    * (x, y) for horizontal/vertical
-//    * omitted for all sides
-// - Size is a number from 0 to 9 (see the $spacer-N variables for sizes)
-// - Breakpoint is an optional responsive breakpoint (sm, md, lg, xl)
-// - Margin auto values are supported and follow the same syntax (e.g. .mx-auto-md)
-//
-// Examples:
-//
-//   .mb4.mb5-md - adds spacer-4 margin to bottom for xs up, and spacer-5 margin for md up
-//   .py1 - adds a spacer-1 padding to top and bottom
-//
 // scss-lint:disable ImportantRule
 // scss-lint:disable SpaceBeforeBrace
 // scss-lint:disable SpaceAfterPropertyColon
@@ -37,22 +19,30 @@
           $size: $i - 1;
           $length: nth($spacers, $i);
 
-          // m0-sm
+          // e.g. m3-sm
           .#{$abbrev}#{$size}#{$suffix}  { #{$prop}:        $length !important; }
 
-          // mt-sm
+          // e.g. mt3-sm
           .#{$abbrev}t#{$size}#{$suffix} { #{$prop}-top:    $length !important; }
           .#{$abbrev}r#{$size}#{$suffix} { #{$prop}-right:  $length !important; }
           .#{$abbrev}b#{$size}#{$suffix} { #{$prop}-bottom: $length !important; }
           .#{$abbrev}l#{$size}#{$suffix} { #{$prop}-left:   $length !important; }
 
-          // mx-sm
+          // e.g. mx3-sm
           .#{$abbrev}x#{$size}#{$suffix} {
             #{$prop}-right: $length !important;
             #{$prop}-left:  $length !important;
           }
 
-          // my-sm
+          @if $abbrev == 'm' {  // negation only applicable for margin
+            // e.g. mxn3-sm
+            .#{$abbrev}xn#{$size}#{$suffix} {
+              #{$prop}-right: -$length !important;
+              #{$prop}-left:  -$length !important;
+            }
+          }
+
+          // e.g. my3-sm
           .#{$abbrev}y#{$size}#{$suffix} {
             #{$prop}-top:    $length !important;
             #{$prop}-bottom: $length !important;


### PR DESCRIPTION
Changes:

* Added `mxn[size]-[breakpoint]` negative margin x-axis helpers to reach parity with Basscss's approach to customizing grid gutters (need to add them to the parent `.row` class to get rid of extra side padding)
* Grid examples now makes more sense: <br><img width="400" alt="screen shot 2017-07-06 at 11 42 39 am" src="https://user-images.githubusercontent.com/396006/27927318-3ca75c02-6240-11e7-97b3-aca9a36bf626.png">
* Added background color for base `.Message` class
* Customized `$container-max-widths` for grid container widths