### PR TITLE
Make header margins 0.5rem?

### DIFF
--- a/styles/_reboot.scss
+++ b/styles/_reboot.scss
@@ -104,7 +104,7 @@ hr {
 // margin for easier control within type scales as it avoids margin collapsing.
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 // Reset margins on paragraphs


### PR DESCRIPTION
I noticed that the margin-bottom was changed from 1rem to 0.5rem in the reboot. I don't know all the potential use cases, but at least for the new marketing copy, using 0.5rem would allow not having to customize the headers. Don't feel super strongly though if you expect 1rem to be more applicable in the future. Alternatively, if the headers on the 3-column section can just go with 1rem instead of 0.5, that would work too.

Comparison of 1rem to 0.5rem in our current marketing stuff:

<img width="300" alt="1rem" src="https://user-images.githubusercontent.com/396006/28179747-c440fe08-67b7-11e7-973e-f3b13ee9411f.png"> <img width="300" alt="0 5rem" src="https://user-images.githubusercontent.com/396006/28179748-c4423c5a-67b7-11e7-8d9c-2a8979566326.png"> 
