### PR TITLE
Add more utilities

### DIFF
--- a/fractal_assets/css/preview.css
+++ b/fractal_assets/css/preview.css
@@ -13,3 +13,7 @@
   background-color: #2dcfa1;
   border: 1px solid #007868;
 }
+
+.sizing-example {
+  background-color: #2dcfa1;
+}

--- a/fractal_react/__components.js
+++ b/fractal_react/__components.js
@@ -11,6 +11,7 @@ module.exports = {
   "display": require("../library/utilities/display/display.jsx"),
   "flexbox": require("../library/utilities/flexbox/flexbox.jsx"),
   "grid": require("../library/utilities/grid/grid.jsx"),
+  "sizing": require("../library/utilities/sizing/sizing.jsx"),
   "spacing": require("../library/utilities/spacing/spacing.jsx"),
   "typography": require("../library/utilities/typography/typography.jsx"),
 };

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -187,7 +187,7 @@
 // Sizers and responsive utilities
 // -------------------------------
 
-@if $enable-form-utilities {
+@if $enable-responsive-form-components {
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
       $suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -123,7 +123,7 @@
   user-select: none;
 }
 
-@if $enable-form-utilities {
+@if $enable-responsive-form-components {
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
       $suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);

--- a/library/components/form_group/_form_group.scss
+++ b/library/components/form_group/_form_group.scss
@@ -56,7 +56,7 @@
 
 @include form-group-sizer;
 
-@if $enable-form-utilities {
+@if $enable-responsive-form-components {
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
       $suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -72,7 +72,7 @@
 // Sizers
 //
 
-@if $enable-form-utilities {
+@if $enable-responsive-form-components {
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {
       $suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);

--- a/library/utilities/flexbox/_flexbox.scss
+++ b/library/utilities/flexbox/_flexbox.scss
@@ -26,6 +26,8 @@
       .flex-nowrap#{$suffix}       { flex-wrap: nowrap !important; }
       .flex-wrap-reverse#{$suffix} { flex-wrap: wrap-reverse !important; }
 
+      .flex-none#{$suffix} { flex: none !important; }
+
       .justify-content-start#{$suffix}   { justify-content: flex-start !important; }
       .justify-content-end#{$suffix}     { justify-content: flex-end !important; }
       .justify-content-center#{$suffix}  { justify-content: center !important; }

--- a/library/utilities/flexbox/_flexbox.scss
+++ b/library/utilities/flexbox/_flexbox.scss
@@ -27,6 +27,7 @@
       .flex-wrap-reverse#{$suffix} { flex-wrap: wrap-reverse !important; }
 
       .flex-none#{$suffix} { flex: none !important; }
+      .flex-1#{$suffix}    { flex: 1 !important; }
 
       .justify-content-start#{$suffix}   { justify-content: flex-start !important; }
       .justify-content-end#{$suffix}     { justify-content: flex-end !important; }

--- a/library/utilities/flexbox/flexbox.jsx
+++ b/library/utilities/flexbox/flexbox.jsx
@@ -242,6 +242,24 @@ function FlexboxUtilities() {
       <Demo classNames="d-flex flex-wrap align-content-stretch" width="500px" height="200px">
         <InnerBox /><InnerBox /><InnerBox /><InnerBox /><InnerBox />
       </Demo>
+
+      <h3 className="mt7">Grow and shrink</h3>
+      <Demo classNames="d-inline-flex">
+        <InnerBox>
+          In this example, this box has so much text in it that it would cause the other box
+          to break lines on the dash. But that box cannot shrink b/c it has the
+          <code>.flex-none</code> class.
+        </InnerBox>
+        <InnerBox className="flex-none">
+          <code>.flex-none</code>
+        </InnerBox>
+      </Demo>
+      <Separator />
+      <Demo classNames="d-flex">
+        <InnerBox className="flex-1"><code>.flex-1</code></InnerBox>
+        <InnerBox />
+        <InnerBox className="flex-1"><code>.flex-1</code></InnerBox>
+      </Demo>
     </div>
   );
 }

--- a/library/utilities/sizing/README.md
+++ b/library/utilities/sizing/README.md
@@ -1,8 +1,8 @@
 Sizing utility classes are available for setting a fixed width or height on an element. The sizing
 utilities share the same modular scale as the [spacing utilities](/components/detail/spacing).
 
-*Note: for widths, [the grid](/components/detail/grid) is preferred. Don't use fixed width sizers
-unless truly necessary.*
+*Note: for fixed widths, [the grid](/components/detail/grid) is preferred. Don't use fixed width
+sizers unless truly necessary.*
 
 ### Classes
 

--- a/library/utilities/sizing/README.md
+++ b/library/utilities/sizing/README.md
@@ -1,0 +1,28 @@
+Sizing utility classes are available for setting a fixed width or height on an element. The sizing
+utilities share the same modular scale as the [spacing utilities](/components/detail/spacing).
+
+*Note: for widths, [the grid](/components/detail/grid) is preferred. Don't use fixed width sizers
+unless truly necessary.*
+
+### Classes
+
+```
+.[property][size][-breakpoint]
+```
+
+* `property` is `width` or `height`
+* `size` is a modular scale number from 0 to 9, or "-full" for 100%.
+* `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
+
+Examples:
+
+* `.width5`
+* `.width-full`
+* `.height3-sm`
+* `.width3.width-full-xl`
+
+Related:
+
+* [Modular Scale](/docs/modular-scale/)
+* [Spacing](/docs/spacing/)
+* [Responsive breakpoints](/docs/layout/#responsive-breakpoints)

--- a/library/utilities/sizing/README.md
+++ b/library/utilities/sizing/README.md
@@ -1,8 +1,8 @@
 Sizing utility classes are available for setting a fixed width or height on an element. The sizing
 utilities share the same modular scale as the [spacing utilities](/components/detail/spacing).
 
-*Note: for fixed widths, [the grid](/components/detail/grid) is preferred. Don't use fixed width
-sizers unless truly necessary.*
+Note: if you don't need fixed widths, [the grid system](/components/detail/grid) is available for
+more detailed percentage-based widthery.
 
 ### Classes
 

--- a/library/utilities/sizing/README.md
+++ b/library/utilities/sizing/README.md
@@ -1,25 +1,23 @@
-Sizing utility classes are available for setting a fixed width or height on an element. The sizing
+Sizing utility classes are available for setting a width or height on an element. The sizing
 utilities share the same modular scale as the [spacing utilities](/components/detail/spacing).
 
-Note: if you don't need fixed widths, [the grid system](/components/detail/grid) is available for
-more detailed percentage-based widthery.
+Note: for percentage width layouts, see the [the grid system](/components/detail/grid).
 
 ### Classes
 
 ```
-.[property][size][-breakpoint]
+.width-[size][-breakpoint]
+.height-[size][-breakpoint]
 ```
 
-* `property` is `width` or `height`
-* `size` is a modular scale number from 0 to 9, or "-full" for 100%.
+* `size` is a modular scale number from 0 to 9, or "full" for 100%.
 * `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
 
 Examples:
 
-* `.width5`
+* `.width-5`
 * `.width-full`
-* `.height3-sm`
-* `.width3.width-full-xl`
+* `.height-3.height-full-xl`
 
 Related:
 

--- a/library/utilities/sizing/_sizing.scss
+++ b/library/utilities/sizing/_sizing.scss
@@ -1,0 +1,33 @@
+// ------------------------------
+// Responsive sizing utilities
+// ------------------------------
+//
+// Width & height classes that use the same modular scale as the spacing classes.
+//
+// [width|height][size][-breakpoint]
+// e.g.: .width5-sm
+//
+// 100% width/height classes are also provided:
+//
+// [width|height]-full[-breakpoint]
+// e.g.: .width-full-sm
+
+// scss-lint:disable ImportantRule
+
+@if $enable-sizing-utilities {
+  @each $breakpoint in map-keys($grid-breakpoints) {
+    @include media-breakpoint-up($breakpoint) {
+      $bp: breakpoint-suffix($breakpoint, $grid-breakpoints);
+
+      @each $dimension in (width, height) {
+        @for $i from 1 through length($spacers) {
+          $size: $i - 1;
+          $length: nth($spacers, $i);
+          .#{$dimension}#{$size}#{$bp} { #{$dimension}: $length !important; }
+        }
+
+        .#{$dimension}-full#{$bp} { #{$dimension}: 100% !important; }
+      }
+    }
+  }
+}

--- a/library/utilities/sizing/_sizing.scss
+++ b/library/utilities/sizing/_sizing.scss
@@ -4,8 +4,8 @@
 //
 // Width & height classes that use the same modular scale as the spacing classes.
 //
-// [width|height][size][-breakpoint]
-// e.g.: .width5-sm
+// [width|height]-[size][-breakpoint]
+// e.g.: .width-5-sm
 //
 // 100% width/height classes are also provided:
 //
@@ -23,7 +23,7 @@
         @for $i from 1 through length($spacers) {
           $size: $i - 1;
           $length: nth($spacers, $i);
-          .#{$dimension}#{$size}#{$bp} { #{$dimension}: $length !important; }
+          .#{$dimension}-#{$size}#{$bp} { #{$dimension}: $length !important; }
         }
 
         .#{$dimension}-full#{$bp} { #{$dimension}: 100% !important; }

--- a/library/utilities/sizing/sizing.config.json
+++ b/library/utilities/sizing/sizing.config.json
@@ -1,0 +1,3 @@
+{
+  "status": "demo"
+}

--- a/library/utilities/sizing/sizing.jsx
+++ b/library/utilities/sizing/sizing.jsx
@@ -6,10 +6,10 @@ function Example({ size }) {
     <div>
       <p>
         <code className="text-color-hint">
-          .width{size}.height{size}
+          .width-{size}.height-{size}
         </code>
       </p>
-      <div className={classes(`width${size}`, `height${size}`, 'sizing-example')} />
+      <div className={classes(`width-${size}`, `height-${size}`, 'sizing-example')} />
       <hr />
     </div>
   );
@@ -28,7 +28,7 @@ function SizingExamples() {
       <Example size={7} />
       <Example size={8} />
       <Example size={9} />
-      <Example size="-full" />
+      <Example size="full" />
     </div>
   );
 }

--- a/library/utilities/sizing/sizing.jsx
+++ b/library/utilities/sizing/sizing.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import classes from 'classnames';
+
+function Example({ size }) {
+  return (
+    <div>
+      <p>
+        <code className="text-color-hint">
+          .width{size}.height{size}
+        </code>
+      </p>
+      <div className={classes(`width${size}`, `height${size}`, 'sizing-example')} />
+      <hr />
+    </div>
+  );
+}
+
+function SizingExamples() {
+  return (
+    <div>
+      <Example size={0} />
+      <Example size={1} />
+      <Example size={2} />
+      <Example size={3} />
+      <Example size={4} />
+      <Example size={5} />
+      <Example size={6} />
+      <Example size={7} />
+      <Example size={8} />
+      <Example size={9} />
+      <Example size="-full" />
+    </div>
+  );
+}
+
+module.exports = SizingExamples;

--- a/library/utilities/spacing/README.md
+++ b/library/utilities/spacing/README.md
@@ -1,4 +1,4 @@
-Spacing utilities and SASS variables allow you to quickly set an element's margin or padding to defined values that align with the Phenotypes modular scale. 
+Spacing utilities and SASS variables allow you to quickly set an element's margin or padding to defined values that align with the Phenotypes modular scale.
 
 ### Responsive classes
 

--- a/library/utilities/spacing/_spacing.scss
+++ b/library/utilities/spacing/_spacing.scss
@@ -35,10 +35,18 @@
           }
 
           @if $abbrev == 'm' {  // negation only applicable for margin
-            // e.g. mxn3-sm
-            .#{$abbrev}xn#{$size}#{$suffix} {
-              #{$prop}-right: -$length !important;
-              #{$prop}-left:  -$length !important;
+            @if $size != 0 { // don't need -0px margins
+              // e.g. mt3-sm
+              .#{$abbrev}tn#{$size}#{$suffix} { #{$prop}-top:    -$length !important; }
+              .#{$abbrev}rn#{$size}#{$suffix} { #{$prop}-right:  -$length !important; }
+              .#{$abbrev}bn#{$size}#{$suffix} { #{$prop}-bottom: -$length !important; }
+              .#{$abbrev}ln#{$size}#{$suffix} { #{$prop}-left:   -$length !important; }
+
+              // e.g. mxn3-sm
+              .#{$abbrev}xn#{$size}#{$suffix} {
+                #{$prop}-right: -$length !important;
+                #{$prop}-left:  -$length !important;
+              }
             }
           }
 

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -64,5 +64,6 @@
 .text-style-italic { font-style: italic !important; }
 .text-style-normal { font-style: normal !important; }
 
+.text-underline { text-decoration: underline !important; }
 
 // TODO: Alignment

--- a/library/utilities/typography/typography.jsx
+++ b/library/utilities/typography/typography.jsx
@@ -120,8 +120,13 @@ function TypographyUtilities() {
       <Label>.text-style-italic</Label>
       <p className="text-style-italic">Italic style</p>
       <hr />
-      <Label>.text-weight-bold.text-style-italic</Label>
-      <p className="text-style-italic text-weight-bold">Bold weight and italic style</p>
+      <Label>.text-underline</Label>
+      <p className="text-underline">Underline</p>
+      <hr />
+      <Label>.text-weight-bold.text-style-italic.text-underline</Label>
+      <p className="text-style-italic text-weight-bold text-underline">
+        Bold, italic, and underline
+      </p>
 
       <hr className="my7" />
 

--- a/styles/_features.scss
+++ b/styles/_features.scss
@@ -29,8 +29,12 @@ $enable-spacing-utilities: true !default;
 // Typography utilities: 344 lines of CSS (approx 10kb)
 $enable-type-utilities: true !default;
 
-// Form utilities: (?) lines of CSS
-$enable-form-utilities: true !default;
-
 // Grid classes:
 $enable-grid-classes: true !default;
+
+// ------------------------------
+// Components
+// ------------------------------
+
+// Responsive form components: (?) lines of CSS
+$enable-responsive-form-components: true !default;

--- a/styles/_features.scss
+++ b/styles/_features.scss
@@ -23,6 +23,9 @@ $enable-display-utilities: true !default;
 // Flexbox utilities: 359 lines of CSS (approx 10kb)
 $enable-flex-utilities: true !default;
 
+// Sizing utilities: 248 lines of CSS
+$enable-sizing-utilities: true !default;
+
 // Spacing utilities: 1835 lines of CSS (approx 42kb)
 $enable-spacing-utilities: true !default;
 

--- a/styles/_utilities.scss
+++ b/styles/_utilities.scss
@@ -1,5 +1,6 @@
 @import 'library/utilities/display/display';
 @import 'library/utilities/flexbox/flexbox';
+@import 'library/utilities/grid/grid';
+@import 'library/utilities/sizing/sizing';
 @import 'library/utilities/spacing/spacing';
 @import 'library/utilities/typography/typography';
-@import 'library/utilities/grid/grid';

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1342,6 +1342,9 @@ hr {
 .flex-wrap-reverse {
   flex-wrap: wrap-reverse !important; }
 
+.flex-none {
+  flex: none !important; }
+
 .justify-content-start {
   justify-content: flex-start !important; }
 
@@ -1429,6 +1432,8 @@ hr {
     flex-wrap: nowrap !important; }
   .flex-wrap-reverse-sm {
     flex-wrap: wrap-reverse !important; }
+  .flex-none-sm {
+    flex: none !important; }
   .justify-content-start-sm {
     justify-content: flex-start !important; }
   .justify-content-end-sm {
@@ -1495,6 +1500,8 @@ hr {
     flex-wrap: nowrap !important; }
   .flex-wrap-reverse-md {
     flex-wrap: wrap-reverse !important; }
+  .flex-none-md {
+    flex: none !important; }
   .justify-content-start-md {
     justify-content: flex-start !important; }
   .justify-content-end-md {
@@ -1561,6 +1568,8 @@ hr {
     flex-wrap: nowrap !important; }
   .flex-wrap-reverse-lg {
     flex-wrap: wrap-reverse !important; }
+  .flex-none-lg {
+    flex: none !important; }
   .justify-content-start-lg {
     justify-content: flex-start !important; }
   .justify-content-end-lg {
@@ -1627,6 +1636,8 @@ hr {
     flex-wrap: nowrap !important; }
   .flex-wrap-reverse-xl {
     flex-wrap: wrap-reverse !important; }
+  .flex-none-xl {
+    flex: none !important; }
   .justify-content-start-xl {
     justify-content: flex-start !important; }
   .justify-content-end-xl {

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -167,18 +167,21 @@ a {
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
-  a:hover {
-    color: #008ab3;
-    text-decoration: underline; }
+
+a:hover {
+  color: #008ab3;
+  text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
   color: inherit;
   text-decoration: none; }
-  a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-    color: inherit;
-    text-decoration: none; }
-  a:not([href]):not([tabindex]):focus {
-    outline: 0; }
+
+a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
+  color: inherit;
+  text-decoration: none; }
+
+a:not([href]):not([tabindex]):focus {
+  outline: 0; }
 
 pre,
 code,
@@ -423,11 +426,13 @@ hr {
   color: #fff;
   font-weight: normal;
   background: #f04d5d; }
-  .Button--danger:hover, .Button--danger:focus, .Button--danger.Button--is-hovered, .Button--danger.Button--is-focused {
-    background: #ee3548;
-    color: #fff; }
-  .Button--danger:active, .Button--danger.Button--is-active {
-    background: #ec192e; }
+
+.Button--danger:hover, .Button--danger:focus, .Button--danger.Button--is-hovered, .Button--danger.Button--is-focused {
+  background: #ee3548;
+  color: #fff; }
+
+.Button--danger:active, .Button--danger.Button--is-active {
+  background: #ec192e; }
 
 .Button--primary {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
@@ -435,23 +440,27 @@ hr {
   font-weight: bold;
   -webkit-font-smoothing: antialiased;
   background: #16b8e0; }
-  .Button--primary:hover, .Button--primary:focus, .Button--primary.Button--is-hovered, .Button--primary.Button--is-focused {
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
-    background: #14a5c9;
-    color: #fff; }
-  .Button--primary:active, .Button--primary.Button--is-active {
-    box-shadow: none;
-    background: #118ead; }
+
+.Button--primary:hover, .Button--primary:focus, .Button--primary.Button--is-hovered, .Button--primary.Button--is-focused {
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
+  background: #14a5c9;
+  color: #fff; }
+
+.Button--primary:active, .Button--primary.Button--is-active {
+  box-shadow: none;
+  background: #118ead; }
 
 .Button--link {
   background: transparent;
   color: #16b8e0; }
-  .Button--link:hover, .Button--link:focus, .Button--link.Button--is-hovered, .Button--link.Button--is-focused {
-    background: rgba(0, 0, 0, 0.05);
-    color: #008ab3; }
-  .Button--link:active, .Button--link.Button--is-active {
-    background: rgba(0, 0, 0, 0.11);
-    color: #005678; }
+
+.Button--link:hover, .Button--link:focus, .Button--link.Button--is-hovered, .Button--link.Button--is-focused {
+  background: rgba(0, 0, 0, 0.05);
+  color: #008ab3; }
+
+.Button--link:active, .Button--link.Button--is-active {
+  background: rgba(0, 0, 0, 0.11);
+  color: #005678; }
 
 @media (pointer: coarse), (any-pointer: coarse) {
   .Button:hover,
@@ -533,43 +542,52 @@ hr {
   display: inline-block;
   margin: 0;
   position: relative; }
-  .Checkbox .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+
+.Checkbox .Checkbox__indicator {
+  background-position: 1px 2px;
+  background-size: 10px 9px;
+  height: 16px;
+  top: 1px;
+  width: 16px; }
 
 .Checkbox__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-  .Checkbox__input:focus ~ .Checkbox__indicator {
-    border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
-  .Checkbox__input:active ~ .Checkbox__indicator {
-    background-color: #f9f9f9;
-    border-color: #c1c1c1; }
-  .Checkbox__input:checked ~ .Checkbox__indicator {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-    background-color: #232323;
-    border-color: #232323; }
-  .Checkbox__input:checked:focus ~ .Checkbox__indicator {
-    border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
-  .Checkbox__input:checked:active ~ .Checkbox__indicator {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-    background-color: #232323;
-    border-color: #232323; }
-  .Checkbox__input:disabled ~ .Checkbox__indicator,
-  .Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
-    background-color: #eee;
-    border-color: #eee; }
-  .Checkbox__input:disabled:checked ~ .Checkbox__indicator,
-  .Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
-  .Checkbox__input:disabled ~ .Checkbox__label {
-    color: rgba(0, 0, 0, 0.54); }
+
+.Checkbox__input:focus ~ .Checkbox__indicator {
+  border-color: #7feaff;
+  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+
+.Checkbox__input:active ~ .Checkbox__indicator {
+  background-color: #f9f9f9;
+  border-color: #c1c1c1; }
+
+.Checkbox__input:checked ~ .Checkbox__indicator {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+  background-color: #232323;
+  border-color: #232323; }
+
+.Checkbox__input:checked:focus ~ .Checkbox__indicator {
+  border-color: #232323;
+  box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+
+.Checkbox__input:checked:active ~ .Checkbox__indicator {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+  background-color: #232323;
+  border-color: #232323; }
+
+.Checkbox__input:disabled ~ .Checkbox__indicator,
+.Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
+  background-color: #eee;
+  border-color: #eee; }
+
+.Checkbox__input:disabled:checked ~ .Checkbox__indicator,
+.Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
+
+.Checkbox__input:disabled ~ .Checkbox__label {
+  color: rgba(0, 0, 0, 0.54); }
 
 .Checkbox__indicator {
   background-color: #fff;
@@ -587,12 +605,13 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 23px; }
-  .Checkbox--medium .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+
+.Checkbox--medium .Checkbox__indicator {
+  background-position: 1px 2px;
+  background-size: 10px 9px;
+  height: 16px;
+  top: 1px;
+  width: 16px; }
 
 .Checkbox--small {
   font-size: 12px;
@@ -600,12 +619,13 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 21px; }
-  .Checkbox--small .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+
+.Checkbox--small .Checkbox__indicator {
+  background-position: 1px 1px;
+  background-size: 8px 8px;
+  height: 14px;
+  top: 1px;
+  width: 14px; }
 
 .Checkbox--large {
   font-size: 18px;
@@ -613,12 +633,13 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 32px; }
-  .Checkbox--large .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; }
+
+.Checkbox--large .Checkbox__indicator {
+  background-position: 2px 3px;
+  background-size: 14px 11px;
+  height: 21px;
+  top: 2px;
+  width: 21px; }
 
 @media (min-width: 600px) {
   .Checkbox--medium-sm {
@@ -627,36 +648,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-sm .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-sm .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-sm {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-sm .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-sm .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-sm {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-sm .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-sm .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 @media (min-width: 900px) {
   .Checkbox--medium-md {
@@ -665,36 +686,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-md .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-md .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-md {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-md .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-md .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-md {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-md .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-md .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 @media (min-width: 1200px) {
   .Checkbox--medium-lg {
@@ -703,36 +724,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-lg .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-lg .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-lg {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-lg .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-lg .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-lg {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-lg .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-lg .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 @media (min-width: 1500px) {
   .Checkbox--medium-xl {
@@ -741,36 +762,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-xl .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-xl .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-xl {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-xl .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-xl .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-xl {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-xl .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-xl .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 .Message {
   background-color: #eee;
@@ -791,8 +812,9 @@ hr {
 
 .Tab {
   display: inline-block; }
-  .Tab:not(:last-child) {
-    margin-right: 0.875em; }
+
+.Tab:not(:last-child) {
+  margin-right: 0.875em; }
 
 .Tab--is-active {
   border-bottom: 2px solid #000; }
@@ -806,9 +828,10 @@ hr {
   color: rgba(0, 0, 0, 0.86);
   line-height: 1.49271;
   width: 100%; }
-  .TextInput::placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
+
+.TextInput::placeholder {
+  color: rgba(0, 0, 0, 0.41);
+  opacity: 1; }
 
 .TextInput:focus,
 .TextInput--is-focused {
@@ -827,10 +850,11 @@ hr {
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
   border-color: #f04d5d; }
-  .TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
-  .FormGroup--has-error .TextInput.TextInput:focus,
-  .FormGroup--has-error .TextInput.TextInput--is-focused {
-    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+
+.TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
+.FormGroup--has-error .TextInput.TextInput:focus,
+.FormGroup--has-error .TextInput.TextInput--is-focused {
+  box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {
@@ -917,9 +941,10 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-  .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+
+.FormGroup__error::before {
+  content: '✘ ';
+  display: inline; }
 
 .FormGroup__hint {
   font-size: 12px;
@@ -956,9 +981,10 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-  .FormGroup--medium .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+
+.FormGroup--medium .FormGroup__error::before {
+  content: '✘ ';
+  display: inline; }
 
 .FormGroup--medium .FormGroup__hint {
   font-size: 12px;
@@ -1011,9 +1037,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-sm .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-sm .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-sm .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1062,9 +1088,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-md .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-md .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-md .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1113,9 +1139,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-lg .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-lg .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-lg .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1164,9 +1190,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-xl .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-xl .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-xl .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -4016,6 +4042,9 @@ hr {
 .text-style-normal {
   font-style: normal !important; }
 
+.text-underline {
+  text-decoration: underline !important; }
+
 .container {
   margin-right: auto;
   margin-left: auto;
@@ -4023,90 +4052,107 @@ hr {
   padding-left: 12px;
   width: 451px;
   max-width: 100%; }
-  @media (min-width: 600px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 600px) {
-    .container {
-      width: 673px;
-      max-width: 100%; } }
-  @media (min-width: 900px) {
-    .container {
-      width: 879px;
-      max-width: 100%; } }
-  @media (min-width: 1200px) {
-    .container {
-      width: 1148px;
-      max-width: 100%; } }
-  @media (min-width: 1500px) {
-    .container {
-      width: 1148px;
-      max-width: 100%; } }
+
+@media (min-width: 600px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container {
+    width: 673px;
+    max-width: 100%; } }
+
+@media (min-width: 900px) {
+  .container {
+    width: 879px;
+    max-width: 100%; } }
+
+@media (min-width: 1200px) {
+  .container {
+    width: 1148px;
+    max-width: 100%; } }
+
+@media (min-width: 1500px) {
+  .container {
+    width: 1148px;
+    max-width: 100%; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
 
 .row {
   display: flex;
   flex-wrap: wrap;
   margin-right: -12px;
   margin-left: -12px; }
-  @media (min-width: 600px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 900px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 1200px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 1500px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
+
+@media (min-width: 600px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 900px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1200px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1500px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
 
 .no-gutters {
   margin-right: 0;
   margin-left: 0; }
-  .no-gutters > .col,
-  .no-gutters > [class*="col-"] {
-    padding-right: 0;
-    padding-left: 0; }
+
+.no-gutters > .col,
+.no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }
 
 .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
   position: relative;
@@ -4114,22 +4160,26 @@ hr {
   min-height: 1px;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
 
 .col {
   flex-basis: 0;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1319,6 +1319,9 @@ hr {
 .flex-none {
   flex: none !important; }
 
+.flex-1 {
+  flex: 1 !important; }
+
 .justify-content-start {
   justify-content: flex-start !important; }
 
@@ -1408,6 +1411,8 @@ hr {
     flex-wrap: wrap-reverse !important; }
   .flex-none-sm {
     flex: none !important; }
+  .flex-1-sm {
+    flex: 1 !important; }
   .justify-content-start-sm {
     justify-content: flex-start !important; }
   .justify-content-end-sm {
@@ -1476,6 +1481,8 @@ hr {
     flex-wrap: wrap-reverse !important; }
   .flex-none-md {
     flex: none !important; }
+  .flex-1-md {
+    flex: 1 !important; }
   .justify-content-start-md {
     justify-content: flex-start !important; }
   .justify-content-end-md {
@@ -1544,6 +1551,8 @@ hr {
     flex-wrap: wrap-reverse !important; }
   .flex-none-lg {
     flex: none !important; }
+  .flex-1-lg {
+    flex: 1 !important; }
   .justify-content-start-lg {
     justify-content: flex-start !important; }
   .justify-content-end-lg {
@@ -1612,6 +1621,8 @@ hr {
     flex-wrap: wrap-reverse !important; }
   .flex-none-xl {
     flex: none !important; }
+  .flex-1-xl {
+    flex: 1 !important; }
   .justify-content-start-xl {
     justify-content: flex-start !important; }
   .justify-content-end-xl {

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1691,10 +1691,6 @@ hr {
   margin-right: 0 !important;
   margin-left: 0 !important; }
 
-.mxn0 {
-  margin-right: 0 !important;
-  margin-left: 0 !important; }
-
 .my0 {
   margin-top: 0 !important;
   margin-bottom: 0 !important; }
@@ -1717,6 +1713,18 @@ hr {
 .mx1 {
   margin-right: 5px !important;
   margin-left: 5px !important; }
+
+.mtn1 {
+  margin-top: -5px !important; }
+
+.mrn1 {
+  margin-right: -5px !important; }
+
+.mbn1 {
+  margin-bottom: -5px !important; }
+
+.mln1 {
+  margin-left: -5px !important; }
 
 .mxn1 {
   margin-right: -5px !important;
@@ -1745,6 +1753,18 @@ hr {
   margin-right: 7px !important;
   margin-left: 7px !important; }
 
+.mtn2 {
+  margin-top: -7px !important; }
+
+.mrn2 {
+  margin-right: -7px !important; }
+
+.mbn2 {
+  margin-bottom: -7px !important; }
+
+.mln2 {
+  margin-left: -7px !important; }
+
 .mxn2 {
   margin-right: -7px !important;
   margin-left: -7px !important; }
@@ -1771,6 +1791,18 @@ hr {
 .mx3 {
   margin-right: 11px !important;
   margin-left: 11px !important; }
+
+.mtn3 {
+  margin-top: -11px !important; }
+
+.mrn3 {
+  margin-right: -11px !important; }
+
+.mbn3 {
+  margin-bottom: -11px !important; }
+
+.mln3 {
+  margin-left: -11px !important; }
 
 .mxn3 {
   margin-right: -11px !important;
@@ -1799,6 +1831,18 @@ hr {
   margin-right: 16px !important;
   margin-left: 16px !important; }
 
+.mtn4 {
+  margin-top: -16px !important; }
+
+.mrn4 {
+  margin-right: -16px !important; }
+
+.mbn4 {
+  margin-bottom: -16px !important; }
+
+.mln4 {
+  margin-left: -16px !important; }
+
 .mxn4 {
   margin-right: -16px !important;
   margin-left: -16px !important; }
@@ -1825,6 +1869,18 @@ hr {
 .mx5 {
   margin-right: 24px !important;
   margin-left: 24px !important; }
+
+.mtn5 {
+  margin-top: -24px !important; }
+
+.mrn5 {
+  margin-right: -24px !important; }
+
+.mbn5 {
+  margin-bottom: -24px !important; }
+
+.mln5 {
+  margin-left: -24px !important; }
 
 .mxn5 {
   margin-right: -24px !important;
@@ -1853,6 +1909,18 @@ hr {
   margin-right: 36px !important;
   margin-left: 36px !important; }
 
+.mtn6 {
+  margin-top: -36px !important; }
+
+.mrn6 {
+  margin-right: -36px !important; }
+
+.mbn6 {
+  margin-bottom: -36px !important; }
+
+.mln6 {
+  margin-left: -36px !important; }
+
 .mxn6 {
   margin-right: -36px !important;
   margin-left: -36px !important; }
@@ -1879,6 +1947,18 @@ hr {
 .mx7 {
   margin-right: 53px !important;
   margin-left: 53px !important; }
+
+.mtn7 {
+  margin-top: -53px !important; }
+
+.mrn7 {
+  margin-right: -53px !important; }
+
+.mbn7 {
+  margin-bottom: -53px !important; }
+
+.mln7 {
+  margin-left: -53px !important; }
 
 .mxn7 {
   margin-right: -53px !important;
@@ -1907,6 +1987,18 @@ hr {
   margin-right: 79px !important;
   margin-left: 79px !important; }
 
+.mtn8 {
+  margin-top: -79px !important; }
+
+.mrn8 {
+  margin-right: -79px !important; }
+
+.mbn8 {
+  margin-bottom: -79px !important; }
+
+.mln8 {
+  margin-left: -79px !important; }
+
 .mxn8 {
   margin-right: -79px !important;
   margin-left: -79px !important; }
@@ -1933,6 +2025,18 @@ hr {
 .mx9 {
   margin-right: 119px !important;
   margin-left: 119px !important; }
+
+.mtn9 {
+  margin-top: -119px !important; }
+
+.mrn9 {
+  margin-right: -119px !important; }
+
+.mbn9 {
+  margin-bottom: -119px !important; }
+
+.mln9 {
+  margin-left: -119px !important; }
 
 .mxn9 {
   margin-right: -119px !important;
@@ -2209,9 +2313,6 @@ hr {
   .mx0-sm {
     margin-right: 0 !important;
     margin-left: 0 !important; }
-  .mxn0-sm {
-    margin-right: 0 !important;
-    margin-left: 0 !important; }
   .my0-sm {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -2228,6 +2329,14 @@ hr {
   .mx1-sm {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mtn1-sm {
+    margin-top: -5px !important; }
+  .mrn1-sm {
+    margin-right: -5px !important; }
+  .mbn1-sm {
+    margin-bottom: -5px !important; }
+  .mln1-sm {
+    margin-left: -5px !important; }
   .mxn1-sm {
     margin-right: -5px !important;
     margin-left: -5px !important; }
@@ -2247,6 +2356,14 @@ hr {
   .mx2-sm {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mtn2-sm {
+    margin-top: -7px !important; }
+  .mrn2-sm {
+    margin-right: -7px !important; }
+  .mbn2-sm {
+    margin-bottom: -7px !important; }
+  .mln2-sm {
+    margin-left: -7px !important; }
   .mxn2-sm {
     margin-right: -7px !important;
     margin-left: -7px !important; }
@@ -2266,6 +2383,14 @@ hr {
   .mx3-sm {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mtn3-sm {
+    margin-top: -11px !important; }
+  .mrn3-sm {
+    margin-right: -11px !important; }
+  .mbn3-sm {
+    margin-bottom: -11px !important; }
+  .mln3-sm {
+    margin-left: -11px !important; }
   .mxn3-sm {
     margin-right: -11px !important;
     margin-left: -11px !important; }
@@ -2285,6 +2410,14 @@ hr {
   .mx4-sm {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mtn4-sm {
+    margin-top: -16px !important; }
+  .mrn4-sm {
+    margin-right: -16px !important; }
+  .mbn4-sm {
+    margin-bottom: -16px !important; }
+  .mln4-sm {
+    margin-left: -16px !important; }
   .mxn4-sm {
     margin-right: -16px !important;
     margin-left: -16px !important; }
@@ -2304,6 +2437,14 @@ hr {
   .mx5-sm {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mtn5-sm {
+    margin-top: -24px !important; }
+  .mrn5-sm {
+    margin-right: -24px !important; }
+  .mbn5-sm {
+    margin-bottom: -24px !important; }
+  .mln5-sm {
+    margin-left: -24px !important; }
   .mxn5-sm {
     margin-right: -24px !important;
     margin-left: -24px !important; }
@@ -2323,6 +2464,14 @@ hr {
   .mx6-sm {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mtn6-sm {
+    margin-top: -36px !important; }
+  .mrn6-sm {
+    margin-right: -36px !important; }
+  .mbn6-sm {
+    margin-bottom: -36px !important; }
+  .mln6-sm {
+    margin-left: -36px !important; }
   .mxn6-sm {
     margin-right: -36px !important;
     margin-left: -36px !important; }
@@ -2342,6 +2491,14 @@ hr {
   .mx7-sm {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mtn7-sm {
+    margin-top: -53px !important; }
+  .mrn7-sm {
+    margin-right: -53px !important; }
+  .mbn7-sm {
+    margin-bottom: -53px !important; }
+  .mln7-sm {
+    margin-left: -53px !important; }
   .mxn7-sm {
     margin-right: -53px !important;
     margin-left: -53px !important; }
@@ -2361,6 +2518,14 @@ hr {
   .mx8-sm {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mtn8-sm {
+    margin-top: -79px !important; }
+  .mrn8-sm {
+    margin-right: -79px !important; }
+  .mbn8-sm {
+    margin-bottom: -79px !important; }
+  .mln8-sm {
+    margin-left: -79px !important; }
   .mxn8-sm {
     margin-right: -79px !important;
     margin-left: -79px !important; }
@@ -2380,6 +2545,14 @@ hr {
   .mx9-sm {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mtn9-sm {
+    margin-top: -119px !important; }
+  .mrn9-sm {
+    margin-right: -119px !important; }
+  .mbn9-sm {
+    margin-bottom: -119px !important; }
+  .mln9-sm {
+    margin-left: -119px !important; }
   .mxn9-sm {
     margin-right: -119px !important;
     margin-left: -119px !important; }
@@ -2577,9 +2750,6 @@ hr {
   .mx0-md {
     margin-right: 0 !important;
     margin-left: 0 !important; }
-  .mxn0-md {
-    margin-right: 0 !important;
-    margin-left: 0 !important; }
   .my0-md {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -2596,6 +2766,14 @@ hr {
   .mx1-md {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mtn1-md {
+    margin-top: -5px !important; }
+  .mrn1-md {
+    margin-right: -5px !important; }
+  .mbn1-md {
+    margin-bottom: -5px !important; }
+  .mln1-md {
+    margin-left: -5px !important; }
   .mxn1-md {
     margin-right: -5px !important;
     margin-left: -5px !important; }
@@ -2615,6 +2793,14 @@ hr {
   .mx2-md {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mtn2-md {
+    margin-top: -7px !important; }
+  .mrn2-md {
+    margin-right: -7px !important; }
+  .mbn2-md {
+    margin-bottom: -7px !important; }
+  .mln2-md {
+    margin-left: -7px !important; }
   .mxn2-md {
     margin-right: -7px !important;
     margin-left: -7px !important; }
@@ -2634,6 +2820,14 @@ hr {
   .mx3-md {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mtn3-md {
+    margin-top: -11px !important; }
+  .mrn3-md {
+    margin-right: -11px !important; }
+  .mbn3-md {
+    margin-bottom: -11px !important; }
+  .mln3-md {
+    margin-left: -11px !important; }
   .mxn3-md {
     margin-right: -11px !important;
     margin-left: -11px !important; }
@@ -2653,6 +2847,14 @@ hr {
   .mx4-md {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mtn4-md {
+    margin-top: -16px !important; }
+  .mrn4-md {
+    margin-right: -16px !important; }
+  .mbn4-md {
+    margin-bottom: -16px !important; }
+  .mln4-md {
+    margin-left: -16px !important; }
   .mxn4-md {
     margin-right: -16px !important;
     margin-left: -16px !important; }
@@ -2672,6 +2874,14 @@ hr {
   .mx5-md {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mtn5-md {
+    margin-top: -24px !important; }
+  .mrn5-md {
+    margin-right: -24px !important; }
+  .mbn5-md {
+    margin-bottom: -24px !important; }
+  .mln5-md {
+    margin-left: -24px !important; }
   .mxn5-md {
     margin-right: -24px !important;
     margin-left: -24px !important; }
@@ -2691,6 +2901,14 @@ hr {
   .mx6-md {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mtn6-md {
+    margin-top: -36px !important; }
+  .mrn6-md {
+    margin-right: -36px !important; }
+  .mbn6-md {
+    margin-bottom: -36px !important; }
+  .mln6-md {
+    margin-left: -36px !important; }
   .mxn6-md {
     margin-right: -36px !important;
     margin-left: -36px !important; }
@@ -2710,6 +2928,14 @@ hr {
   .mx7-md {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mtn7-md {
+    margin-top: -53px !important; }
+  .mrn7-md {
+    margin-right: -53px !important; }
+  .mbn7-md {
+    margin-bottom: -53px !important; }
+  .mln7-md {
+    margin-left: -53px !important; }
   .mxn7-md {
     margin-right: -53px !important;
     margin-left: -53px !important; }
@@ -2729,6 +2955,14 @@ hr {
   .mx8-md {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mtn8-md {
+    margin-top: -79px !important; }
+  .mrn8-md {
+    margin-right: -79px !important; }
+  .mbn8-md {
+    margin-bottom: -79px !important; }
+  .mln8-md {
+    margin-left: -79px !important; }
   .mxn8-md {
     margin-right: -79px !important;
     margin-left: -79px !important; }
@@ -2748,6 +2982,14 @@ hr {
   .mx9-md {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mtn9-md {
+    margin-top: -119px !important; }
+  .mrn9-md {
+    margin-right: -119px !important; }
+  .mbn9-md {
+    margin-bottom: -119px !important; }
+  .mln9-md {
+    margin-left: -119px !important; }
   .mxn9-md {
     margin-right: -119px !important;
     margin-left: -119px !important; }
@@ -2945,9 +3187,6 @@ hr {
   .mx0-lg {
     margin-right: 0 !important;
     margin-left: 0 !important; }
-  .mxn0-lg {
-    margin-right: 0 !important;
-    margin-left: 0 !important; }
   .my0-lg {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -2964,6 +3203,14 @@ hr {
   .mx1-lg {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mtn1-lg {
+    margin-top: -5px !important; }
+  .mrn1-lg {
+    margin-right: -5px !important; }
+  .mbn1-lg {
+    margin-bottom: -5px !important; }
+  .mln1-lg {
+    margin-left: -5px !important; }
   .mxn1-lg {
     margin-right: -5px !important;
     margin-left: -5px !important; }
@@ -2983,6 +3230,14 @@ hr {
   .mx2-lg {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mtn2-lg {
+    margin-top: -7px !important; }
+  .mrn2-lg {
+    margin-right: -7px !important; }
+  .mbn2-lg {
+    margin-bottom: -7px !important; }
+  .mln2-lg {
+    margin-left: -7px !important; }
   .mxn2-lg {
     margin-right: -7px !important;
     margin-left: -7px !important; }
@@ -3002,6 +3257,14 @@ hr {
   .mx3-lg {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mtn3-lg {
+    margin-top: -11px !important; }
+  .mrn3-lg {
+    margin-right: -11px !important; }
+  .mbn3-lg {
+    margin-bottom: -11px !important; }
+  .mln3-lg {
+    margin-left: -11px !important; }
   .mxn3-lg {
     margin-right: -11px !important;
     margin-left: -11px !important; }
@@ -3021,6 +3284,14 @@ hr {
   .mx4-lg {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mtn4-lg {
+    margin-top: -16px !important; }
+  .mrn4-lg {
+    margin-right: -16px !important; }
+  .mbn4-lg {
+    margin-bottom: -16px !important; }
+  .mln4-lg {
+    margin-left: -16px !important; }
   .mxn4-lg {
     margin-right: -16px !important;
     margin-left: -16px !important; }
@@ -3040,6 +3311,14 @@ hr {
   .mx5-lg {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mtn5-lg {
+    margin-top: -24px !important; }
+  .mrn5-lg {
+    margin-right: -24px !important; }
+  .mbn5-lg {
+    margin-bottom: -24px !important; }
+  .mln5-lg {
+    margin-left: -24px !important; }
   .mxn5-lg {
     margin-right: -24px !important;
     margin-left: -24px !important; }
@@ -3059,6 +3338,14 @@ hr {
   .mx6-lg {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mtn6-lg {
+    margin-top: -36px !important; }
+  .mrn6-lg {
+    margin-right: -36px !important; }
+  .mbn6-lg {
+    margin-bottom: -36px !important; }
+  .mln6-lg {
+    margin-left: -36px !important; }
   .mxn6-lg {
     margin-right: -36px !important;
     margin-left: -36px !important; }
@@ -3078,6 +3365,14 @@ hr {
   .mx7-lg {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mtn7-lg {
+    margin-top: -53px !important; }
+  .mrn7-lg {
+    margin-right: -53px !important; }
+  .mbn7-lg {
+    margin-bottom: -53px !important; }
+  .mln7-lg {
+    margin-left: -53px !important; }
   .mxn7-lg {
     margin-right: -53px !important;
     margin-left: -53px !important; }
@@ -3097,6 +3392,14 @@ hr {
   .mx8-lg {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mtn8-lg {
+    margin-top: -79px !important; }
+  .mrn8-lg {
+    margin-right: -79px !important; }
+  .mbn8-lg {
+    margin-bottom: -79px !important; }
+  .mln8-lg {
+    margin-left: -79px !important; }
   .mxn8-lg {
     margin-right: -79px !important;
     margin-left: -79px !important; }
@@ -3116,6 +3419,14 @@ hr {
   .mx9-lg {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mtn9-lg {
+    margin-top: -119px !important; }
+  .mrn9-lg {
+    margin-right: -119px !important; }
+  .mbn9-lg {
+    margin-bottom: -119px !important; }
+  .mln9-lg {
+    margin-left: -119px !important; }
   .mxn9-lg {
     margin-right: -119px !important;
     margin-left: -119px !important; }
@@ -3313,9 +3624,6 @@ hr {
   .mx0-xl {
     margin-right: 0 !important;
     margin-left: 0 !important; }
-  .mxn0-xl {
-    margin-right: 0 !important;
-    margin-left: 0 !important; }
   .my0-xl {
     margin-top: 0 !important;
     margin-bottom: 0 !important; }
@@ -3332,6 +3640,14 @@ hr {
   .mx1-xl {
     margin-right: 5px !important;
     margin-left: 5px !important; }
+  .mtn1-xl {
+    margin-top: -5px !important; }
+  .mrn1-xl {
+    margin-right: -5px !important; }
+  .mbn1-xl {
+    margin-bottom: -5px !important; }
+  .mln1-xl {
+    margin-left: -5px !important; }
   .mxn1-xl {
     margin-right: -5px !important;
     margin-left: -5px !important; }
@@ -3351,6 +3667,14 @@ hr {
   .mx2-xl {
     margin-right: 7px !important;
     margin-left: 7px !important; }
+  .mtn2-xl {
+    margin-top: -7px !important; }
+  .mrn2-xl {
+    margin-right: -7px !important; }
+  .mbn2-xl {
+    margin-bottom: -7px !important; }
+  .mln2-xl {
+    margin-left: -7px !important; }
   .mxn2-xl {
     margin-right: -7px !important;
     margin-left: -7px !important; }
@@ -3370,6 +3694,14 @@ hr {
   .mx3-xl {
     margin-right: 11px !important;
     margin-left: 11px !important; }
+  .mtn3-xl {
+    margin-top: -11px !important; }
+  .mrn3-xl {
+    margin-right: -11px !important; }
+  .mbn3-xl {
+    margin-bottom: -11px !important; }
+  .mln3-xl {
+    margin-left: -11px !important; }
   .mxn3-xl {
     margin-right: -11px !important;
     margin-left: -11px !important; }
@@ -3389,6 +3721,14 @@ hr {
   .mx4-xl {
     margin-right: 16px !important;
     margin-left: 16px !important; }
+  .mtn4-xl {
+    margin-top: -16px !important; }
+  .mrn4-xl {
+    margin-right: -16px !important; }
+  .mbn4-xl {
+    margin-bottom: -16px !important; }
+  .mln4-xl {
+    margin-left: -16px !important; }
   .mxn4-xl {
     margin-right: -16px !important;
     margin-left: -16px !important; }
@@ -3408,6 +3748,14 @@ hr {
   .mx5-xl {
     margin-right: 24px !important;
     margin-left: 24px !important; }
+  .mtn5-xl {
+    margin-top: -24px !important; }
+  .mrn5-xl {
+    margin-right: -24px !important; }
+  .mbn5-xl {
+    margin-bottom: -24px !important; }
+  .mln5-xl {
+    margin-left: -24px !important; }
   .mxn5-xl {
     margin-right: -24px !important;
     margin-left: -24px !important; }
@@ -3427,6 +3775,14 @@ hr {
   .mx6-xl {
     margin-right: 36px !important;
     margin-left: 36px !important; }
+  .mtn6-xl {
+    margin-top: -36px !important; }
+  .mrn6-xl {
+    margin-right: -36px !important; }
+  .mbn6-xl {
+    margin-bottom: -36px !important; }
+  .mln6-xl {
+    margin-left: -36px !important; }
   .mxn6-xl {
     margin-right: -36px !important;
     margin-left: -36px !important; }
@@ -3446,6 +3802,14 @@ hr {
   .mx7-xl {
     margin-right: 53px !important;
     margin-left: 53px !important; }
+  .mtn7-xl {
+    margin-top: -53px !important; }
+  .mrn7-xl {
+    margin-right: -53px !important; }
+  .mbn7-xl {
+    margin-bottom: -53px !important; }
+  .mln7-xl {
+    margin-left: -53px !important; }
   .mxn7-xl {
     margin-right: -53px !important;
     margin-left: -53px !important; }
@@ -3465,6 +3829,14 @@ hr {
   .mx8-xl {
     margin-right: 79px !important;
     margin-left: 79px !important; }
+  .mtn8-xl {
+    margin-top: -79px !important; }
+  .mrn8-xl {
+    margin-right: -79px !important; }
+  .mbn8-xl {
+    margin-bottom: -79px !important; }
+  .mln8-xl {
+    margin-left: -79px !important; }
   .mxn8-xl {
     margin-right: -79px !important;
     margin-left: -79px !important; }
@@ -3484,6 +3856,14 @@ hr {
   .mx9-xl {
     margin-right: 119px !important;
     margin-left: 119px !important; }
+  .mtn9-xl {
+    margin-top: -119px !important; }
+  .mrn9-xl {
+    margin-right: -119px !important; }
+  .mbn9-xl {
+    margin-bottom: -119px !important; }
+  .mln9-xl {
+    margin-left: -119px !important; }
   .mxn9-xl {
     margin-right: -119px !important;
     margin-left: -119px !important; }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -167,21 +167,18 @@ a {
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
-
-a:hover {
-  color: #008ab3;
-  text-decoration: underline; }
+  a:hover {
+    color: #008ab3;
+    text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
   color: inherit;
   text-decoration: none; }
-
-a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-  color: inherit;
-  text-decoration: none; }
-
-a:not([href]):not([tabindex]):focus {
-  outline: 0; }
+  a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
+    color: inherit;
+    text-decoration: none; }
+  a:not([href]):not([tabindex]):focus {
+    outline: 0; }
 
 pre,
 code,
@@ -426,13 +423,11 @@ hr {
   color: #fff;
   font-weight: normal;
   background: #f04d5d; }
-
-.Button--danger:hover, .Button--danger:focus, .Button--danger.Button--is-hovered, .Button--danger.Button--is-focused {
-  background: #ee3548;
-  color: #fff; }
-
-.Button--danger:active, .Button--danger.Button--is-active {
-  background: #ec192e; }
+  .Button--danger:hover, .Button--danger:focus, .Button--danger.Button--is-hovered, .Button--danger.Button--is-focused {
+    background: #ee3548;
+    color: #fff; }
+  .Button--danger:active, .Button--danger.Button--is-active {
+    background: #ec192e; }
 
 .Button--primary {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
@@ -440,27 +435,23 @@ hr {
   font-weight: bold;
   -webkit-font-smoothing: antialiased;
   background: #16b8e0; }
-
-.Button--primary:hover, .Button--primary:focus, .Button--primary.Button--is-hovered, .Button--primary.Button--is-focused {
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
-  background: #14a5c9;
-  color: #fff; }
-
-.Button--primary:active, .Button--primary.Button--is-active {
-  box-shadow: none;
-  background: #118ead; }
+  .Button--primary:hover, .Button--primary:focus, .Button--primary.Button--is-hovered, .Button--primary.Button--is-focused {
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
+    background: #14a5c9;
+    color: #fff; }
+  .Button--primary:active, .Button--primary.Button--is-active {
+    box-shadow: none;
+    background: #118ead; }
 
 .Button--link {
   background: transparent;
   color: #16b8e0; }
-
-.Button--link:hover, .Button--link:focus, .Button--link.Button--is-hovered, .Button--link.Button--is-focused {
-  background: rgba(0, 0, 0, 0.05);
-  color: #008ab3; }
-
-.Button--link:active, .Button--link.Button--is-active {
-  background: rgba(0, 0, 0, 0.11);
-  color: #005678; }
+  .Button--link:hover, .Button--link:focus, .Button--link.Button--is-hovered, .Button--link.Button--is-focused {
+    background: rgba(0, 0, 0, 0.05);
+    color: #008ab3; }
+  .Button--link:active, .Button--link.Button--is-active {
+    background: rgba(0, 0, 0, 0.11);
+    color: #005678; }
 
 @media (pointer: coarse), (any-pointer: coarse) {
   .Button:hover,
@@ -542,52 +533,43 @@ hr {
   display: inline-block;
   margin: 0;
   position: relative; }
-
-.Checkbox .Checkbox__indicator {
-  background-position: 1px 2px;
-  background-size: 10px 9px;
-  height: 16px;
-  top: 1px;
-  width: 16px; }
+  .Checkbox .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
 
 .Checkbox__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-
-.Checkbox__input:focus ~ .Checkbox__indicator {
-  border-color: #7feaff;
-  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
-
-.Checkbox__input:active ~ .Checkbox__indicator {
-  background-color: #f9f9f9;
-  border-color: #c1c1c1; }
-
-.Checkbox__input:checked ~ .Checkbox__indicator {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-  background-color: #232323;
-  border-color: #232323; }
-
-.Checkbox__input:checked:focus ~ .Checkbox__indicator {
-  border-color: #232323;
-  box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
-
-.Checkbox__input:checked:active ~ .Checkbox__indicator {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-  background-color: #232323;
-  border-color: #232323; }
-
-.Checkbox__input:disabled ~ .Checkbox__indicator,
-.Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
-  background-color: #eee;
-  border-color: #eee; }
-
-.Checkbox__input:disabled:checked ~ .Checkbox__indicator,
-.Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
-
-.Checkbox__input:disabled ~ .Checkbox__label {
-  color: rgba(0, 0, 0, 0.54); }
+  .Checkbox__input:focus ~ .Checkbox__indicator {
+    border-color: #7feaff;
+    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+  .Checkbox__input:active ~ .Checkbox__indicator {
+    background-color: #f9f9f9;
+    border-color: #c1c1c1; }
+  .Checkbox__input:checked ~ .Checkbox__indicator {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+    background-color: #232323;
+    border-color: #232323; }
+  .Checkbox__input:checked:focus ~ .Checkbox__indicator {
+    border-color: #232323;
+    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+  .Checkbox__input:checked:active ~ .Checkbox__indicator {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+    background-color: #232323;
+    border-color: #232323; }
+  .Checkbox__input:disabled ~ .Checkbox__indicator,
+  .Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
+    background-color: #eee;
+    border-color: #eee; }
+  .Checkbox__input:disabled:checked ~ .Checkbox__indicator,
+  .Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
+  .Checkbox__input:disabled ~ .Checkbox__label {
+    color: rgba(0, 0, 0, 0.54); }
 
 .Checkbox__indicator {
   background-color: #fff;
@@ -605,13 +587,12 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 23px; }
-
-.Checkbox--medium .Checkbox__indicator {
-  background-position: 1px 2px;
-  background-size: 10px 9px;
-  height: 16px;
-  top: 1px;
-  width: 16px; }
+  .Checkbox--medium .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
 
 .Checkbox--small {
   font-size: 12px;
@@ -619,13 +600,12 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 21px; }
-
-.Checkbox--small .Checkbox__indicator {
-  background-position: 1px 1px;
-  background-size: 8px 8px;
-  height: 14px;
-  top: 1px;
-  width: 14px; }
+  .Checkbox--small .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
 
 .Checkbox--large {
   font-size: 18px;
@@ -633,13 +613,12 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 32px; }
-
-.Checkbox--large .Checkbox__indicator {
-  background-position: 2px 3px;
-  background-size: 14px 11px;
-  height: 21px;
-  top: 2px;
-  width: 21px; }
+  .Checkbox--large .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; }
 
 @media (min-width: 600px) {
   .Checkbox--medium-sm {
@@ -648,36 +627,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-sm .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-sm .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-sm {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-sm .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-sm .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-sm {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-sm .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-sm .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 @media (min-width: 900px) {
   .Checkbox--medium-md {
@@ -686,36 +665,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-md .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-md .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-md {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-md .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-md .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-md {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-md .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-md .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 @media (min-width: 1200px) {
   .Checkbox--medium-lg {
@@ -724,36 +703,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-lg .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-lg .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-lg {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-lg .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-lg .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-lg {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-lg .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-lg .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 @media (min-width: 1500px) {
   .Checkbox--medium-xl {
@@ -762,36 +741,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-xl .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-xl .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-xl {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-xl .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-xl .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-xl {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-xl .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-xl .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 .Message {
   background-color: #eee;
@@ -812,9 +791,8 @@ hr {
 
 .Tab {
   display: inline-block; }
-
-.Tab:not(:last-child) {
-  margin-right: 0.875em; }
+  .Tab:not(:last-child) {
+    margin-right: 0.875em; }
 
 .Tab--is-active {
   border-bottom: 2px solid #000; }
@@ -828,10 +806,9 @@ hr {
   color: rgba(0, 0, 0, 0.86);
   line-height: 1.49271;
   width: 100%; }
-
-.TextInput::placeholder {
-  color: rgba(0, 0, 0, 0.41);
-  opacity: 1; }
+  .TextInput::placeholder {
+    color: rgba(0, 0, 0, 0.41);
+    opacity: 1; }
 
 .TextInput:focus,
 .TextInput--is-focused {
@@ -850,11 +827,10 @@ hr {
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
   border-color: #f04d5d; }
-
-.TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
-.FormGroup--has-error .TextInput.TextInput:focus,
-.FormGroup--has-error .TextInput.TextInput--is-focused {
-  box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+  .TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
+  .FormGroup--has-error .TextInput.TextInput:focus,
+  .FormGroup--has-error .TextInput.TextInput--is-focused {
+    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {
@@ -941,10 +917,9 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-
-.FormGroup__error::before {
-  content: '✘ ';
-  display: inline; }
+  .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
 
 .FormGroup__hint {
   font-size: 12px;
@@ -981,10 +956,9 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-
-.FormGroup--medium .FormGroup__error::before {
-  content: '✘ ';
-  display: inline; }
+  .FormGroup--medium .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
 
 .FormGroup--medium .FormGroup__hint {
   font-size: 12px;
@@ -1037,9 +1011,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-sm .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-sm .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-sm .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1088,9 +1062,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-md .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-md .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-md .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1139,9 +1113,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-lg .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-lg .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-lg .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1190,9 +1164,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-xl .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-xl .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-xl .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1690,107 +1664,90 @@ hr {
   padding-left: 12px;
   width: 451px;
   max-width: 100%; }
-
-@media (min-width: 600px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 600px) {
-  .container {
-    width: 673px;
-    max-width: 100%; } }
-
-@media (min-width: 900px) {
-  .container {
-    width: 879px;
-    max-width: 100%; } }
-
-@media (min-width: 1200px) {
-  .container {
-    width: 1148px;
-    max-width: 100%; } }
-
-@media (min-width: 1500px) {
-  .container {
-    width: 1148px;
-    max-width: 100%; } }
+  @media (min-width: 600px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .container {
+      width: 673px;
+      max-width: 100%; } }
+  @media (min-width: 900px) {
+    .container {
+      width: 879px;
+      max-width: 100%; } }
+  @media (min-width: 1200px) {
+    .container {
+      width: 1148px;
+      max-width: 100%; } }
+  @media (min-width: 1500px) {
+    .container {
+      width: 1148px;
+      max-width: 100%; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
 
 .row {
   display: flex;
   flex-wrap: wrap;
   margin-right: -12px;
   margin-left: -12px; }
-
-@media (min-width: 600px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 900px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1200px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1500px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
+  @media (min-width: 600px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 900px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 1200px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 1500px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
 
 .no-gutters {
   margin-right: 0;
   margin-left: 0; }
-
-.no-gutters > .col,
-.no-gutters > [class*="col-"] {
-  padding-right: 0;
-  padding-left: 0; }
+  .no-gutters > .col,
+  .no-gutters > [class*="col-"] {
+    padding-right: 0;
+    padding-left: 0; }
 
 .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
   position: relative;
@@ -1798,26 +1755,22 @@ hr {
   min-height: 1px;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
 
 .col {
   flex-basis: 0;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -2471,6 +2471,256 @@ hr {
   .offset-11-xl {
     margin-left: 91.66667%; } }
 
+.width0 {
+  width: 0 !important; }
+
+.width1 {
+  width: 5px !important; }
+
+.width2 {
+  width: 7px !important; }
+
+.width3 {
+  width: 11px !important; }
+
+.width4 {
+  width: 16px !important; }
+
+.width5 {
+  width: 24px !important; }
+
+.width6 {
+  width: 36px !important; }
+
+.width7 {
+  width: 53px !important; }
+
+.width8 {
+  width: 79px !important; }
+
+.width9 {
+  width: 119px !important; }
+
+.width-full {
+  width: 100% !important; }
+
+.height0 {
+  height: 0 !important; }
+
+.height1 {
+  height: 5px !important; }
+
+.height2 {
+  height: 7px !important; }
+
+.height3 {
+  height: 11px !important; }
+
+.height4 {
+  height: 16px !important; }
+
+.height5 {
+  height: 24px !important; }
+
+.height6 {
+  height: 36px !important; }
+
+.height7 {
+  height: 53px !important; }
+
+.height8 {
+  height: 79px !important; }
+
+.height9 {
+  height: 119px !important; }
+
+.height-full {
+  height: 100% !important; }
+
+@media (min-width: 600px) {
+  .width0-sm {
+    width: 0 !important; }
+  .width1-sm {
+    width: 5px !important; }
+  .width2-sm {
+    width: 7px !important; }
+  .width3-sm {
+    width: 11px !important; }
+  .width4-sm {
+    width: 16px !important; }
+  .width5-sm {
+    width: 24px !important; }
+  .width6-sm {
+    width: 36px !important; }
+  .width7-sm {
+    width: 53px !important; }
+  .width8-sm {
+    width: 79px !important; }
+  .width9-sm {
+    width: 119px !important; }
+  .width-full-sm {
+    width: 100% !important; }
+  .height0-sm {
+    height: 0 !important; }
+  .height1-sm {
+    height: 5px !important; }
+  .height2-sm {
+    height: 7px !important; }
+  .height3-sm {
+    height: 11px !important; }
+  .height4-sm {
+    height: 16px !important; }
+  .height5-sm {
+    height: 24px !important; }
+  .height6-sm {
+    height: 36px !important; }
+  .height7-sm {
+    height: 53px !important; }
+  .height8-sm {
+    height: 79px !important; }
+  .height9-sm {
+    height: 119px !important; }
+  .height-full-sm {
+    height: 100% !important; } }
+
+@media (min-width: 900px) {
+  .width0-md {
+    width: 0 !important; }
+  .width1-md {
+    width: 5px !important; }
+  .width2-md {
+    width: 7px !important; }
+  .width3-md {
+    width: 11px !important; }
+  .width4-md {
+    width: 16px !important; }
+  .width5-md {
+    width: 24px !important; }
+  .width6-md {
+    width: 36px !important; }
+  .width7-md {
+    width: 53px !important; }
+  .width8-md {
+    width: 79px !important; }
+  .width9-md {
+    width: 119px !important; }
+  .width-full-md {
+    width: 100% !important; }
+  .height0-md {
+    height: 0 !important; }
+  .height1-md {
+    height: 5px !important; }
+  .height2-md {
+    height: 7px !important; }
+  .height3-md {
+    height: 11px !important; }
+  .height4-md {
+    height: 16px !important; }
+  .height5-md {
+    height: 24px !important; }
+  .height6-md {
+    height: 36px !important; }
+  .height7-md {
+    height: 53px !important; }
+  .height8-md {
+    height: 79px !important; }
+  .height9-md {
+    height: 119px !important; }
+  .height-full-md {
+    height: 100% !important; } }
+
+@media (min-width: 1200px) {
+  .width0-lg {
+    width: 0 !important; }
+  .width1-lg {
+    width: 5px !important; }
+  .width2-lg {
+    width: 7px !important; }
+  .width3-lg {
+    width: 11px !important; }
+  .width4-lg {
+    width: 16px !important; }
+  .width5-lg {
+    width: 24px !important; }
+  .width6-lg {
+    width: 36px !important; }
+  .width7-lg {
+    width: 53px !important; }
+  .width8-lg {
+    width: 79px !important; }
+  .width9-lg {
+    width: 119px !important; }
+  .width-full-lg {
+    width: 100% !important; }
+  .height0-lg {
+    height: 0 !important; }
+  .height1-lg {
+    height: 5px !important; }
+  .height2-lg {
+    height: 7px !important; }
+  .height3-lg {
+    height: 11px !important; }
+  .height4-lg {
+    height: 16px !important; }
+  .height5-lg {
+    height: 24px !important; }
+  .height6-lg {
+    height: 36px !important; }
+  .height7-lg {
+    height: 53px !important; }
+  .height8-lg {
+    height: 79px !important; }
+  .height9-lg {
+    height: 119px !important; }
+  .height-full-lg {
+    height: 100% !important; } }
+
+@media (min-width: 1500px) {
+  .width0-xl {
+    width: 0 !important; }
+  .width1-xl {
+    width: 5px !important; }
+  .width2-xl {
+    width: 7px !important; }
+  .width3-xl {
+    width: 11px !important; }
+  .width4-xl {
+    width: 16px !important; }
+  .width5-xl {
+    width: 24px !important; }
+  .width6-xl {
+    width: 36px !important; }
+  .width7-xl {
+    width: 53px !important; }
+  .width8-xl {
+    width: 79px !important; }
+  .width9-xl {
+    width: 119px !important; }
+  .width-full-xl {
+    width: 100% !important; }
+  .height0-xl {
+    height: 0 !important; }
+  .height1-xl {
+    height: 5px !important; }
+  .height2-xl {
+    height: 7px !important; }
+  .height3-xl {
+    height: 11px !important; }
+  .height4-xl {
+    height: 16px !important; }
+  .height5-xl {
+    height: 24px !important; }
+  .height6-xl {
+    height: 36px !important; }
+  .height7-xl {
+    height: 53px !important; }
+  .height8-xl {
+    height: 79px !important; }
+  .height9-xl {
+    height: 119px !important; }
+  .height-full-xl {
+    height: 100% !important; } }
+
 .m0 {
   margin: 0 !important; }
 

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -2424,252 +2424,252 @@ hr {
   .offset-11-xl {
     margin-left: 91.66667%; } }
 
-.width0 {
+.width-0 {
   width: 0 !important; }
 
-.width1 {
+.width-1 {
   width: 5px !important; }
 
-.width2 {
+.width-2 {
   width: 7px !important; }
 
-.width3 {
+.width-3 {
   width: 11px !important; }
 
-.width4 {
+.width-4 {
   width: 16px !important; }
 
-.width5 {
+.width-5 {
   width: 24px !important; }
 
-.width6 {
+.width-6 {
   width: 36px !important; }
 
-.width7 {
+.width-7 {
   width: 53px !important; }
 
-.width8 {
+.width-8 {
   width: 79px !important; }
 
-.width9 {
+.width-9 {
   width: 119px !important; }
 
 .width-full {
   width: 100% !important; }
 
-.height0 {
+.height-0 {
   height: 0 !important; }
 
-.height1 {
+.height-1 {
   height: 5px !important; }
 
-.height2 {
+.height-2 {
   height: 7px !important; }
 
-.height3 {
+.height-3 {
   height: 11px !important; }
 
-.height4 {
+.height-4 {
   height: 16px !important; }
 
-.height5 {
+.height-5 {
   height: 24px !important; }
 
-.height6 {
+.height-6 {
   height: 36px !important; }
 
-.height7 {
+.height-7 {
   height: 53px !important; }
 
-.height8 {
+.height-8 {
   height: 79px !important; }
 
-.height9 {
+.height-9 {
   height: 119px !important; }
 
 .height-full {
   height: 100% !important; }
 
 @media (min-width: 600px) {
-  .width0-sm {
+  .width-0-sm {
     width: 0 !important; }
-  .width1-sm {
+  .width-1-sm {
     width: 5px !important; }
-  .width2-sm {
+  .width-2-sm {
     width: 7px !important; }
-  .width3-sm {
+  .width-3-sm {
     width: 11px !important; }
-  .width4-sm {
+  .width-4-sm {
     width: 16px !important; }
-  .width5-sm {
+  .width-5-sm {
     width: 24px !important; }
-  .width6-sm {
+  .width-6-sm {
     width: 36px !important; }
-  .width7-sm {
+  .width-7-sm {
     width: 53px !important; }
-  .width8-sm {
+  .width-8-sm {
     width: 79px !important; }
-  .width9-sm {
+  .width-9-sm {
     width: 119px !important; }
   .width-full-sm {
     width: 100% !important; }
-  .height0-sm {
+  .height-0-sm {
     height: 0 !important; }
-  .height1-sm {
+  .height-1-sm {
     height: 5px !important; }
-  .height2-sm {
+  .height-2-sm {
     height: 7px !important; }
-  .height3-sm {
+  .height-3-sm {
     height: 11px !important; }
-  .height4-sm {
+  .height-4-sm {
     height: 16px !important; }
-  .height5-sm {
+  .height-5-sm {
     height: 24px !important; }
-  .height6-sm {
+  .height-6-sm {
     height: 36px !important; }
-  .height7-sm {
+  .height-7-sm {
     height: 53px !important; }
-  .height8-sm {
+  .height-8-sm {
     height: 79px !important; }
-  .height9-sm {
+  .height-9-sm {
     height: 119px !important; }
   .height-full-sm {
     height: 100% !important; } }
 
 @media (min-width: 900px) {
-  .width0-md {
+  .width-0-md {
     width: 0 !important; }
-  .width1-md {
+  .width-1-md {
     width: 5px !important; }
-  .width2-md {
+  .width-2-md {
     width: 7px !important; }
-  .width3-md {
+  .width-3-md {
     width: 11px !important; }
-  .width4-md {
+  .width-4-md {
     width: 16px !important; }
-  .width5-md {
+  .width-5-md {
     width: 24px !important; }
-  .width6-md {
+  .width-6-md {
     width: 36px !important; }
-  .width7-md {
+  .width-7-md {
     width: 53px !important; }
-  .width8-md {
+  .width-8-md {
     width: 79px !important; }
-  .width9-md {
+  .width-9-md {
     width: 119px !important; }
   .width-full-md {
     width: 100% !important; }
-  .height0-md {
+  .height-0-md {
     height: 0 !important; }
-  .height1-md {
+  .height-1-md {
     height: 5px !important; }
-  .height2-md {
+  .height-2-md {
     height: 7px !important; }
-  .height3-md {
+  .height-3-md {
     height: 11px !important; }
-  .height4-md {
+  .height-4-md {
     height: 16px !important; }
-  .height5-md {
+  .height-5-md {
     height: 24px !important; }
-  .height6-md {
+  .height-6-md {
     height: 36px !important; }
-  .height7-md {
+  .height-7-md {
     height: 53px !important; }
-  .height8-md {
+  .height-8-md {
     height: 79px !important; }
-  .height9-md {
+  .height-9-md {
     height: 119px !important; }
   .height-full-md {
     height: 100% !important; } }
 
 @media (min-width: 1200px) {
-  .width0-lg {
+  .width-0-lg {
     width: 0 !important; }
-  .width1-lg {
+  .width-1-lg {
     width: 5px !important; }
-  .width2-lg {
+  .width-2-lg {
     width: 7px !important; }
-  .width3-lg {
+  .width-3-lg {
     width: 11px !important; }
-  .width4-lg {
+  .width-4-lg {
     width: 16px !important; }
-  .width5-lg {
+  .width-5-lg {
     width: 24px !important; }
-  .width6-lg {
+  .width-6-lg {
     width: 36px !important; }
-  .width7-lg {
+  .width-7-lg {
     width: 53px !important; }
-  .width8-lg {
+  .width-8-lg {
     width: 79px !important; }
-  .width9-lg {
+  .width-9-lg {
     width: 119px !important; }
   .width-full-lg {
     width: 100% !important; }
-  .height0-lg {
+  .height-0-lg {
     height: 0 !important; }
-  .height1-lg {
+  .height-1-lg {
     height: 5px !important; }
-  .height2-lg {
+  .height-2-lg {
     height: 7px !important; }
-  .height3-lg {
+  .height-3-lg {
     height: 11px !important; }
-  .height4-lg {
+  .height-4-lg {
     height: 16px !important; }
-  .height5-lg {
+  .height-5-lg {
     height: 24px !important; }
-  .height6-lg {
+  .height-6-lg {
     height: 36px !important; }
-  .height7-lg {
+  .height-7-lg {
     height: 53px !important; }
-  .height8-lg {
+  .height-8-lg {
     height: 79px !important; }
-  .height9-lg {
+  .height-9-lg {
     height: 119px !important; }
   .height-full-lg {
     height: 100% !important; } }
 
 @media (min-width: 1500px) {
-  .width0-xl {
+  .width-0-xl {
     width: 0 !important; }
-  .width1-xl {
+  .width-1-xl {
     width: 5px !important; }
-  .width2-xl {
+  .width-2-xl {
     width: 7px !important; }
-  .width3-xl {
+  .width-3-xl {
     width: 11px !important; }
-  .width4-xl {
+  .width-4-xl {
     width: 16px !important; }
-  .width5-xl {
+  .width-5-xl {
     width: 24px !important; }
-  .width6-xl {
+  .width-6-xl {
     width: 36px !important; }
-  .width7-xl {
+  .width-7-xl {
     width: 53px !important; }
-  .width8-xl {
+  .width-8-xl {
     width: 79px !important; }
-  .width9-xl {
+  .width-9-xl {
     width: 119px !important; }
   .width-full-xl {
     width: 100% !important; }
-  .height0-xl {
+  .height-0-xl {
     height: 0 !important; }
-  .height1-xl {
+  .height-1-xl {
     height: 5px !important; }
-  .height2-xl {
+  .height-2-xl {
     height: 7px !important; }
-  .height3-xl {
+  .height-3-xl {
     height: 11px !important; }
-  .height4-xl {
+  .height-4-xl {
     height: 16px !important; }
-  .height5-xl {
+  .height-5-xl {
     height: 24px !important; }
-  .height6-xl {
+  .height-6-xl {
     height: 36px !important; }
-  .height7-xl {
+  .height-7-xl {
     height: 53px !important; }
-  .height8-xl {
+  .height-8-xl {
     height: 79px !important; }
-  .height9-xl {
+  .height-9-xl {
     height: 119px !important; }
   .height-full-xl {
     height: 100% !important; } }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1683,6 +1683,794 @@ hr {
   .align-self-stretch-xl {
     align-self: stretch !important; } }
 
+.container {
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 12px;
+  padding-left: 12px;
+  width: 451px;
+  max-width: 100%; }
+
+@media (min-width: 600px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container {
+    width: 673px;
+    max-width: 100%; } }
+
+@media (min-width: 900px) {
+  .container {
+    width: 879px;
+    max-width: 100%; } }
+
+@media (min-width: 1200px) {
+  .container {
+    width: 1148px;
+    max-width: 100%; } }
+
+@media (min-width: 1500px) {
+  .container {
+    width: 1148px;
+    max-width: 100%; } }
+
+.container-fluid {
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 12px;
+  padding-left: 12px; }
+
+@media (min-width: 600px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  margin-right: -12px;
+  margin-left: -12px; }
+
+@media (min-width: 600px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 900px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1200px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1500px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+.no-gutters {
+  margin-right: 0;
+  margin-left: 0; }
+
+.no-gutters > .col,
+.no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }
+
+.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-right: 12px;
+  padding-left: 12px; }
+
+@media (min-width: 600px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+.col {
+  flex-basis: 0;
+  flex-grow: 1;
+  max-width: 100%; }
+
+.col-auto {
+  flex: 0 0 auto;
+  width: auto; }
+
+.col-1 {
+  flex: 0 0 8.33333%;
+  max-width: 8.33333%; }
+
+.col-2 {
+  flex: 0 0 16.66667%;
+  max-width: 16.66667%; }
+
+.col-3 {
+  flex: 0 0 25%;
+  max-width: 25%; }
+
+.col-4 {
+  flex: 0 0 33.33333%;
+  max-width: 33.33333%; }
+
+.col-5 {
+  flex: 0 0 41.66667%;
+  max-width: 41.66667%; }
+
+.col-6 {
+  flex: 0 0 50%;
+  max-width: 50%; }
+
+.col-7 {
+  flex: 0 0 58.33333%;
+  max-width: 58.33333%; }
+
+.col-8 {
+  flex: 0 0 66.66667%;
+  max-width: 66.66667%; }
+
+.col-9 {
+  flex: 0 0 75%;
+  max-width: 75%; }
+
+.col-10 {
+  flex: 0 0 83.33333%;
+  max-width: 83.33333%; }
+
+.col-11 {
+  flex: 0 0 91.66667%;
+  max-width: 91.66667%; }
+
+.col-12 {
+  flex: 0 0 100%;
+  max-width: 100%; }
+
+.pull-0 {
+  right: auto; }
+
+.pull-1 {
+  right: 8.33333%; }
+
+.pull-2 {
+  right: 16.66667%; }
+
+.pull-3 {
+  right: 25%; }
+
+.pull-4 {
+  right: 33.33333%; }
+
+.pull-5 {
+  right: 41.66667%; }
+
+.pull-6 {
+  right: 50%; }
+
+.pull-7 {
+  right: 58.33333%; }
+
+.pull-8 {
+  right: 66.66667%; }
+
+.pull-9 {
+  right: 75%; }
+
+.pull-10 {
+  right: 83.33333%; }
+
+.pull-11 {
+  right: 91.66667%; }
+
+.pull-12 {
+  right: 100%; }
+
+.push-0 {
+  left: auto; }
+
+.push-1 {
+  left: 8.33333%; }
+
+.push-2 {
+  left: 16.66667%; }
+
+.push-3 {
+  left: 25%; }
+
+.push-4 {
+  left: 33.33333%; }
+
+.push-5 {
+  left: 41.66667%; }
+
+.push-6 {
+  left: 50%; }
+
+.push-7 {
+  left: 58.33333%; }
+
+.push-8 {
+  left: 66.66667%; }
+
+.push-9 {
+  left: 75%; }
+
+.push-10 {
+  left: 83.33333%; }
+
+.push-11 {
+  left: 91.66667%; }
+
+.push-12 {
+  left: 100%; }
+
+.offset-1 {
+  margin-left: 8.33333%; }
+
+.offset-2 {
+  margin-left: 16.66667%; }
+
+.offset-3 {
+  margin-left: 25%; }
+
+.offset-4 {
+  margin-left: 33.33333%; }
+
+.offset-5 {
+  margin-left: 41.66667%; }
+
+.offset-6 {
+  margin-left: 50%; }
+
+.offset-7 {
+  margin-left: 58.33333%; }
+
+.offset-8 {
+  margin-left: 66.66667%; }
+
+.offset-9 {
+  margin-left: 75%; }
+
+.offset-10 {
+  margin-left: 83.33333%; }
+
+.offset-11 {
+  margin-left: 91.66667%; }
+
+@media (min-width: 600px) {
+  .col-sm {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .col-sm-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .col-1-sm {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .col-2-sm {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .col-3-sm {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .col-4-sm {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .col-5-sm {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .col-6-sm {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .col-7-sm {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .col-8-sm {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .col-9-sm {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .col-10-sm {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .col-11-sm {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .col-12-sm {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .pull-0-sm {
+    right: auto; }
+  .pull-1-sm {
+    right: 8.33333%; }
+  .pull-2-sm {
+    right: 16.66667%; }
+  .pull-3-sm {
+    right: 25%; }
+  .pull-4-sm {
+    right: 33.33333%; }
+  .pull-5-sm {
+    right: 41.66667%; }
+  .pull-6-sm {
+    right: 50%; }
+  .pull-7-sm {
+    right: 58.33333%; }
+  .pull-8-sm {
+    right: 66.66667%; }
+  .pull-9-sm {
+    right: 75%; }
+  .pull-10-sm {
+    right: 83.33333%; }
+  .pull-11-sm {
+    right: 91.66667%; }
+  .pull-12-sm {
+    right: 100%; }
+  .push-0-sm {
+    left: auto; }
+  .push-1-sm {
+    left: 8.33333%; }
+  .push-2-sm {
+    left: 16.66667%; }
+  .push-3-sm {
+    left: 25%; }
+  .push-4-sm {
+    left: 33.33333%; }
+  .push-5-sm {
+    left: 41.66667%; }
+  .push-6-sm {
+    left: 50%; }
+  .push-7-sm {
+    left: 58.33333%; }
+  .push-8-sm {
+    left: 66.66667%; }
+  .push-9-sm {
+    left: 75%; }
+  .push-10-sm {
+    left: 83.33333%; }
+  .push-11-sm {
+    left: 91.66667%; }
+  .push-12-sm {
+    left: 100%; }
+  .offset-0-sm {
+    margin-left: 0%; }
+  .offset-1-sm {
+    margin-left: 8.33333%; }
+  .offset-2-sm {
+    margin-left: 16.66667%; }
+  .offset-3-sm {
+    margin-left: 25%; }
+  .offset-4-sm {
+    margin-left: 33.33333%; }
+  .offset-5-sm {
+    margin-left: 41.66667%; }
+  .offset-6-sm {
+    margin-left: 50%; }
+  .offset-7-sm {
+    margin-left: 58.33333%; }
+  .offset-8-sm {
+    margin-left: 66.66667%; }
+  .offset-9-sm {
+    margin-left: 75%; }
+  .offset-10-sm {
+    margin-left: 83.33333%; }
+  .offset-11-sm {
+    margin-left: 91.66667%; } }
+
+@media (min-width: 900px) {
+  .col-md {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .col-md-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .col-1-md {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .col-2-md {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .col-3-md {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .col-4-md {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .col-5-md {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .col-6-md {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .col-7-md {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .col-8-md {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .col-9-md {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .col-10-md {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .col-11-md {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .col-12-md {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .pull-0-md {
+    right: auto; }
+  .pull-1-md {
+    right: 8.33333%; }
+  .pull-2-md {
+    right: 16.66667%; }
+  .pull-3-md {
+    right: 25%; }
+  .pull-4-md {
+    right: 33.33333%; }
+  .pull-5-md {
+    right: 41.66667%; }
+  .pull-6-md {
+    right: 50%; }
+  .pull-7-md {
+    right: 58.33333%; }
+  .pull-8-md {
+    right: 66.66667%; }
+  .pull-9-md {
+    right: 75%; }
+  .pull-10-md {
+    right: 83.33333%; }
+  .pull-11-md {
+    right: 91.66667%; }
+  .pull-12-md {
+    right: 100%; }
+  .push-0-md {
+    left: auto; }
+  .push-1-md {
+    left: 8.33333%; }
+  .push-2-md {
+    left: 16.66667%; }
+  .push-3-md {
+    left: 25%; }
+  .push-4-md {
+    left: 33.33333%; }
+  .push-5-md {
+    left: 41.66667%; }
+  .push-6-md {
+    left: 50%; }
+  .push-7-md {
+    left: 58.33333%; }
+  .push-8-md {
+    left: 66.66667%; }
+  .push-9-md {
+    left: 75%; }
+  .push-10-md {
+    left: 83.33333%; }
+  .push-11-md {
+    left: 91.66667%; }
+  .push-12-md {
+    left: 100%; }
+  .offset-0-md {
+    margin-left: 0%; }
+  .offset-1-md {
+    margin-left: 8.33333%; }
+  .offset-2-md {
+    margin-left: 16.66667%; }
+  .offset-3-md {
+    margin-left: 25%; }
+  .offset-4-md {
+    margin-left: 33.33333%; }
+  .offset-5-md {
+    margin-left: 41.66667%; }
+  .offset-6-md {
+    margin-left: 50%; }
+  .offset-7-md {
+    margin-left: 58.33333%; }
+  .offset-8-md {
+    margin-left: 66.66667%; }
+  .offset-9-md {
+    margin-left: 75%; }
+  .offset-10-md {
+    margin-left: 83.33333%; }
+  .offset-11-md {
+    margin-left: 91.66667%; } }
+
+@media (min-width: 1200px) {
+  .col-lg {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .col-lg-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .col-1-lg {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .col-2-lg {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .col-3-lg {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .col-4-lg {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .col-5-lg {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .col-6-lg {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .col-7-lg {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .col-8-lg {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .col-9-lg {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .col-10-lg {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .col-11-lg {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .col-12-lg {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .pull-0-lg {
+    right: auto; }
+  .pull-1-lg {
+    right: 8.33333%; }
+  .pull-2-lg {
+    right: 16.66667%; }
+  .pull-3-lg {
+    right: 25%; }
+  .pull-4-lg {
+    right: 33.33333%; }
+  .pull-5-lg {
+    right: 41.66667%; }
+  .pull-6-lg {
+    right: 50%; }
+  .pull-7-lg {
+    right: 58.33333%; }
+  .pull-8-lg {
+    right: 66.66667%; }
+  .pull-9-lg {
+    right: 75%; }
+  .pull-10-lg {
+    right: 83.33333%; }
+  .pull-11-lg {
+    right: 91.66667%; }
+  .pull-12-lg {
+    right: 100%; }
+  .push-0-lg {
+    left: auto; }
+  .push-1-lg {
+    left: 8.33333%; }
+  .push-2-lg {
+    left: 16.66667%; }
+  .push-3-lg {
+    left: 25%; }
+  .push-4-lg {
+    left: 33.33333%; }
+  .push-5-lg {
+    left: 41.66667%; }
+  .push-6-lg {
+    left: 50%; }
+  .push-7-lg {
+    left: 58.33333%; }
+  .push-8-lg {
+    left: 66.66667%; }
+  .push-9-lg {
+    left: 75%; }
+  .push-10-lg {
+    left: 83.33333%; }
+  .push-11-lg {
+    left: 91.66667%; }
+  .push-12-lg {
+    left: 100%; }
+  .offset-0-lg {
+    margin-left: 0%; }
+  .offset-1-lg {
+    margin-left: 8.33333%; }
+  .offset-2-lg {
+    margin-left: 16.66667%; }
+  .offset-3-lg {
+    margin-left: 25%; }
+  .offset-4-lg {
+    margin-left: 33.33333%; }
+  .offset-5-lg {
+    margin-left: 41.66667%; }
+  .offset-6-lg {
+    margin-left: 50%; }
+  .offset-7-lg {
+    margin-left: 58.33333%; }
+  .offset-8-lg {
+    margin-left: 66.66667%; }
+  .offset-9-lg {
+    margin-left: 75%; }
+  .offset-10-lg {
+    margin-left: 83.33333%; }
+  .offset-11-lg {
+    margin-left: 91.66667%; } }
+
+@media (min-width: 1500px) {
+  .col-xl {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%; }
+  .col-xl-auto {
+    flex: 0 0 auto;
+    width: auto; }
+  .col-1-xl {
+    flex: 0 0 8.33333%;
+    max-width: 8.33333%; }
+  .col-2-xl {
+    flex: 0 0 16.66667%;
+    max-width: 16.66667%; }
+  .col-3-xl {
+    flex: 0 0 25%;
+    max-width: 25%; }
+  .col-4-xl {
+    flex: 0 0 33.33333%;
+    max-width: 33.33333%; }
+  .col-5-xl {
+    flex: 0 0 41.66667%;
+    max-width: 41.66667%; }
+  .col-6-xl {
+    flex: 0 0 50%;
+    max-width: 50%; }
+  .col-7-xl {
+    flex: 0 0 58.33333%;
+    max-width: 58.33333%; }
+  .col-8-xl {
+    flex: 0 0 66.66667%;
+    max-width: 66.66667%; }
+  .col-9-xl {
+    flex: 0 0 75%;
+    max-width: 75%; }
+  .col-10-xl {
+    flex: 0 0 83.33333%;
+    max-width: 83.33333%; }
+  .col-11-xl {
+    flex: 0 0 91.66667%;
+    max-width: 91.66667%; }
+  .col-12-xl {
+    flex: 0 0 100%;
+    max-width: 100%; }
+  .pull-0-xl {
+    right: auto; }
+  .pull-1-xl {
+    right: 8.33333%; }
+  .pull-2-xl {
+    right: 16.66667%; }
+  .pull-3-xl {
+    right: 25%; }
+  .pull-4-xl {
+    right: 33.33333%; }
+  .pull-5-xl {
+    right: 41.66667%; }
+  .pull-6-xl {
+    right: 50%; }
+  .pull-7-xl {
+    right: 58.33333%; }
+  .pull-8-xl {
+    right: 66.66667%; }
+  .pull-9-xl {
+    right: 75%; }
+  .pull-10-xl {
+    right: 83.33333%; }
+  .pull-11-xl {
+    right: 91.66667%; }
+  .pull-12-xl {
+    right: 100%; }
+  .push-0-xl {
+    left: auto; }
+  .push-1-xl {
+    left: 8.33333%; }
+  .push-2-xl {
+    left: 16.66667%; }
+  .push-3-xl {
+    left: 25%; }
+  .push-4-xl {
+    left: 33.33333%; }
+  .push-5-xl {
+    left: 41.66667%; }
+  .push-6-xl {
+    left: 50%; }
+  .push-7-xl {
+    left: 58.33333%; }
+  .push-8-xl {
+    left: 66.66667%; }
+  .push-9-xl {
+    left: 75%; }
+  .push-10-xl {
+    left: 83.33333%; }
+  .push-11-xl {
+    left: 91.66667%; }
+  .push-12-xl {
+    left: 100%; }
+  .offset-0-xl {
+    margin-left: 0%; }
+  .offset-1-xl {
+    margin-left: 8.33333%; }
+  .offset-2-xl {
+    margin-left: 16.66667%; }
+  .offset-3-xl {
+    margin-left: 25%; }
+  .offset-4-xl {
+    margin-left: 33.33333%; }
+  .offset-5-xl {
+    margin-left: 41.66667%; }
+  .offset-6-xl {
+    margin-left: 50%; }
+  .offset-7-xl {
+    margin-left: 58.33333%; }
+  .offset-8-xl {
+    margin-left: 66.66667%; }
+  .offset-9-xl {
+    margin-left: 75%; }
+  .offset-10-xl {
+    margin-left: 83.33333%; }
+  .offset-11-xl {
+    margin-left: 91.66667%; } }
+
 .m0 {
   margin: 0 !important; }
 
@@ -4435,791 +5223,3 @@ hr {
 
 .text-underline {
   text-decoration: underline !important; }
-
-.container {
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: 12px;
-  padding-left: 12px;
-  width: 451px;
-  max-width: 100%; }
-
-@media (min-width: 600px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 600px) {
-  .container {
-    width: 673px;
-    max-width: 100%; } }
-
-@media (min-width: 900px) {
-  .container {
-    width: 879px;
-    max-width: 100%; } }
-
-@media (min-width: 1200px) {
-  .container {
-    width: 1148px;
-    max-width: 100%; } }
-
-@media (min-width: 1500px) {
-  .container {
-    width: 1148px;
-    max-width: 100%; } }
-
-.container-fluid {
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: 12px;
-  padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-.row {
-  display: flex;
-  flex-wrap: wrap;
-  margin-right: -12px;
-  margin-left: -12px; }
-
-@media (min-width: 600px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 900px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1200px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1500px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-.no-gutters {
-  margin-right: 0;
-  margin-left: 0; }
-
-.no-gutters > .col,
-.no-gutters > [class*="col-"] {
-  padding-right: 0;
-  padding-left: 0; }
-
-.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-  position: relative;
-  width: 100%;
-  min-height: 1px;
-  padding-right: 12px;
-  padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-.col {
-  flex-basis: 0;
-  flex-grow: 1;
-  max-width: 100%; }
-
-.col-auto {
-  flex: 0 0 auto;
-  width: auto; }
-
-.col-1 {
-  flex: 0 0 8.33333%;
-  max-width: 8.33333%; }
-
-.col-2 {
-  flex: 0 0 16.66667%;
-  max-width: 16.66667%; }
-
-.col-3 {
-  flex: 0 0 25%;
-  max-width: 25%; }
-
-.col-4 {
-  flex: 0 0 33.33333%;
-  max-width: 33.33333%; }
-
-.col-5 {
-  flex: 0 0 41.66667%;
-  max-width: 41.66667%; }
-
-.col-6 {
-  flex: 0 0 50%;
-  max-width: 50%; }
-
-.col-7 {
-  flex: 0 0 58.33333%;
-  max-width: 58.33333%; }
-
-.col-8 {
-  flex: 0 0 66.66667%;
-  max-width: 66.66667%; }
-
-.col-9 {
-  flex: 0 0 75%;
-  max-width: 75%; }
-
-.col-10 {
-  flex: 0 0 83.33333%;
-  max-width: 83.33333%; }
-
-.col-11 {
-  flex: 0 0 91.66667%;
-  max-width: 91.66667%; }
-
-.col-12 {
-  flex: 0 0 100%;
-  max-width: 100%; }
-
-.pull-0 {
-  right: auto; }
-
-.pull-1 {
-  right: 8.33333%; }
-
-.pull-2 {
-  right: 16.66667%; }
-
-.pull-3 {
-  right: 25%; }
-
-.pull-4 {
-  right: 33.33333%; }
-
-.pull-5 {
-  right: 41.66667%; }
-
-.pull-6 {
-  right: 50%; }
-
-.pull-7 {
-  right: 58.33333%; }
-
-.pull-8 {
-  right: 66.66667%; }
-
-.pull-9 {
-  right: 75%; }
-
-.pull-10 {
-  right: 83.33333%; }
-
-.pull-11 {
-  right: 91.66667%; }
-
-.pull-12 {
-  right: 100%; }
-
-.push-0 {
-  left: auto; }
-
-.push-1 {
-  left: 8.33333%; }
-
-.push-2 {
-  left: 16.66667%; }
-
-.push-3 {
-  left: 25%; }
-
-.push-4 {
-  left: 33.33333%; }
-
-.push-5 {
-  left: 41.66667%; }
-
-.push-6 {
-  left: 50%; }
-
-.push-7 {
-  left: 58.33333%; }
-
-.push-8 {
-  left: 66.66667%; }
-
-.push-9 {
-  left: 75%; }
-
-.push-10 {
-  left: 83.33333%; }
-
-.push-11 {
-  left: 91.66667%; }
-
-.push-12 {
-  left: 100%; }
-
-.offset-1 {
-  margin-left: 8.33333%; }
-
-.offset-2 {
-  margin-left: 16.66667%; }
-
-.offset-3 {
-  margin-left: 25%; }
-
-.offset-4 {
-  margin-left: 33.33333%; }
-
-.offset-5 {
-  margin-left: 41.66667%; }
-
-.offset-6 {
-  margin-left: 50%; }
-
-.offset-7 {
-  margin-left: 58.33333%; }
-
-.offset-8 {
-  margin-left: 66.66667%; }
-
-.offset-9 {
-  margin-left: 75%; }
-
-.offset-10 {
-  margin-left: 83.33333%; }
-
-.offset-11 {
-  margin-left: 91.66667%; }
-
-@media (min-width: 600px) {
-  .col-sm {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%; }
-  .col-sm-auto {
-    flex: 0 0 auto;
-    width: auto; }
-  .col-1-sm {
-    flex: 0 0 8.33333%;
-    max-width: 8.33333%; }
-  .col-2-sm {
-    flex: 0 0 16.66667%;
-    max-width: 16.66667%; }
-  .col-3-sm {
-    flex: 0 0 25%;
-    max-width: 25%; }
-  .col-4-sm {
-    flex: 0 0 33.33333%;
-    max-width: 33.33333%; }
-  .col-5-sm {
-    flex: 0 0 41.66667%;
-    max-width: 41.66667%; }
-  .col-6-sm {
-    flex: 0 0 50%;
-    max-width: 50%; }
-  .col-7-sm {
-    flex: 0 0 58.33333%;
-    max-width: 58.33333%; }
-  .col-8-sm {
-    flex: 0 0 66.66667%;
-    max-width: 66.66667%; }
-  .col-9-sm {
-    flex: 0 0 75%;
-    max-width: 75%; }
-  .col-10-sm {
-    flex: 0 0 83.33333%;
-    max-width: 83.33333%; }
-  .col-11-sm {
-    flex: 0 0 91.66667%;
-    max-width: 91.66667%; }
-  .col-12-sm {
-    flex: 0 0 100%;
-    max-width: 100%; }
-  .pull-0-sm {
-    right: auto; }
-  .pull-1-sm {
-    right: 8.33333%; }
-  .pull-2-sm {
-    right: 16.66667%; }
-  .pull-3-sm {
-    right: 25%; }
-  .pull-4-sm {
-    right: 33.33333%; }
-  .pull-5-sm {
-    right: 41.66667%; }
-  .pull-6-sm {
-    right: 50%; }
-  .pull-7-sm {
-    right: 58.33333%; }
-  .pull-8-sm {
-    right: 66.66667%; }
-  .pull-9-sm {
-    right: 75%; }
-  .pull-10-sm {
-    right: 83.33333%; }
-  .pull-11-sm {
-    right: 91.66667%; }
-  .pull-12-sm {
-    right: 100%; }
-  .push-0-sm {
-    left: auto; }
-  .push-1-sm {
-    left: 8.33333%; }
-  .push-2-sm {
-    left: 16.66667%; }
-  .push-3-sm {
-    left: 25%; }
-  .push-4-sm {
-    left: 33.33333%; }
-  .push-5-sm {
-    left: 41.66667%; }
-  .push-6-sm {
-    left: 50%; }
-  .push-7-sm {
-    left: 58.33333%; }
-  .push-8-sm {
-    left: 66.66667%; }
-  .push-9-sm {
-    left: 75%; }
-  .push-10-sm {
-    left: 83.33333%; }
-  .push-11-sm {
-    left: 91.66667%; }
-  .push-12-sm {
-    left: 100%; }
-  .offset-0-sm {
-    margin-left: 0%; }
-  .offset-1-sm {
-    margin-left: 8.33333%; }
-  .offset-2-sm {
-    margin-left: 16.66667%; }
-  .offset-3-sm {
-    margin-left: 25%; }
-  .offset-4-sm {
-    margin-left: 33.33333%; }
-  .offset-5-sm {
-    margin-left: 41.66667%; }
-  .offset-6-sm {
-    margin-left: 50%; }
-  .offset-7-sm {
-    margin-left: 58.33333%; }
-  .offset-8-sm {
-    margin-left: 66.66667%; }
-  .offset-9-sm {
-    margin-left: 75%; }
-  .offset-10-sm {
-    margin-left: 83.33333%; }
-  .offset-11-sm {
-    margin-left: 91.66667%; } }
-
-@media (min-width: 900px) {
-  .col-md {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%; }
-  .col-md-auto {
-    flex: 0 0 auto;
-    width: auto; }
-  .col-1-md {
-    flex: 0 0 8.33333%;
-    max-width: 8.33333%; }
-  .col-2-md {
-    flex: 0 0 16.66667%;
-    max-width: 16.66667%; }
-  .col-3-md {
-    flex: 0 0 25%;
-    max-width: 25%; }
-  .col-4-md {
-    flex: 0 0 33.33333%;
-    max-width: 33.33333%; }
-  .col-5-md {
-    flex: 0 0 41.66667%;
-    max-width: 41.66667%; }
-  .col-6-md {
-    flex: 0 0 50%;
-    max-width: 50%; }
-  .col-7-md {
-    flex: 0 0 58.33333%;
-    max-width: 58.33333%; }
-  .col-8-md {
-    flex: 0 0 66.66667%;
-    max-width: 66.66667%; }
-  .col-9-md {
-    flex: 0 0 75%;
-    max-width: 75%; }
-  .col-10-md {
-    flex: 0 0 83.33333%;
-    max-width: 83.33333%; }
-  .col-11-md {
-    flex: 0 0 91.66667%;
-    max-width: 91.66667%; }
-  .col-12-md {
-    flex: 0 0 100%;
-    max-width: 100%; }
-  .pull-0-md {
-    right: auto; }
-  .pull-1-md {
-    right: 8.33333%; }
-  .pull-2-md {
-    right: 16.66667%; }
-  .pull-3-md {
-    right: 25%; }
-  .pull-4-md {
-    right: 33.33333%; }
-  .pull-5-md {
-    right: 41.66667%; }
-  .pull-6-md {
-    right: 50%; }
-  .pull-7-md {
-    right: 58.33333%; }
-  .pull-8-md {
-    right: 66.66667%; }
-  .pull-9-md {
-    right: 75%; }
-  .pull-10-md {
-    right: 83.33333%; }
-  .pull-11-md {
-    right: 91.66667%; }
-  .pull-12-md {
-    right: 100%; }
-  .push-0-md {
-    left: auto; }
-  .push-1-md {
-    left: 8.33333%; }
-  .push-2-md {
-    left: 16.66667%; }
-  .push-3-md {
-    left: 25%; }
-  .push-4-md {
-    left: 33.33333%; }
-  .push-5-md {
-    left: 41.66667%; }
-  .push-6-md {
-    left: 50%; }
-  .push-7-md {
-    left: 58.33333%; }
-  .push-8-md {
-    left: 66.66667%; }
-  .push-9-md {
-    left: 75%; }
-  .push-10-md {
-    left: 83.33333%; }
-  .push-11-md {
-    left: 91.66667%; }
-  .push-12-md {
-    left: 100%; }
-  .offset-0-md {
-    margin-left: 0%; }
-  .offset-1-md {
-    margin-left: 8.33333%; }
-  .offset-2-md {
-    margin-left: 16.66667%; }
-  .offset-3-md {
-    margin-left: 25%; }
-  .offset-4-md {
-    margin-left: 33.33333%; }
-  .offset-5-md {
-    margin-left: 41.66667%; }
-  .offset-6-md {
-    margin-left: 50%; }
-  .offset-7-md {
-    margin-left: 58.33333%; }
-  .offset-8-md {
-    margin-left: 66.66667%; }
-  .offset-9-md {
-    margin-left: 75%; }
-  .offset-10-md {
-    margin-left: 83.33333%; }
-  .offset-11-md {
-    margin-left: 91.66667%; } }
-
-@media (min-width: 1200px) {
-  .col-lg {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%; }
-  .col-lg-auto {
-    flex: 0 0 auto;
-    width: auto; }
-  .col-1-lg {
-    flex: 0 0 8.33333%;
-    max-width: 8.33333%; }
-  .col-2-lg {
-    flex: 0 0 16.66667%;
-    max-width: 16.66667%; }
-  .col-3-lg {
-    flex: 0 0 25%;
-    max-width: 25%; }
-  .col-4-lg {
-    flex: 0 0 33.33333%;
-    max-width: 33.33333%; }
-  .col-5-lg {
-    flex: 0 0 41.66667%;
-    max-width: 41.66667%; }
-  .col-6-lg {
-    flex: 0 0 50%;
-    max-width: 50%; }
-  .col-7-lg {
-    flex: 0 0 58.33333%;
-    max-width: 58.33333%; }
-  .col-8-lg {
-    flex: 0 0 66.66667%;
-    max-width: 66.66667%; }
-  .col-9-lg {
-    flex: 0 0 75%;
-    max-width: 75%; }
-  .col-10-lg {
-    flex: 0 0 83.33333%;
-    max-width: 83.33333%; }
-  .col-11-lg {
-    flex: 0 0 91.66667%;
-    max-width: 91.66667%; }
-  .col-12-lg {
-    flex: 0 0 100%;
-    max-width: 100%; }
-  .pull-0-lg {
-    right: auto; }
-  .pull-1-lg {
-    right: 8.33333%; }
-  .pull-2-lg {
-    right: 16.66667%; }
-  .pull-3-lg {
-    right: 25%; }
-  .pull-4-lg {
-    right: 33.33333%; }
-  .pull-5-lg {
-    right: 41.66667%; }
-  .pull-6-lg {
-    right: 50%; }
-  .pull-7-lg {
-    right: 58.33333%; }
-  .pull-8-lg {
-    right: 66.66667%; }
-  .pull-9-lg {
-    right: 75%; }
-  .pull-10-lg {
-    right: 83.33333%; }
-  .pull-11-lg {
-    right: 91.66667%; }
-  .pull-12-lg {
-    right: 100%; }
-  .push-0-lg {
-    left: auto; }
-  .push-1-lg {
-    left: 8.33333%; }
-  .push-2-lg {
-    left: 16.66667%; }
-  .push-3-lg {
-    left: 25%; }
-  .push-4-lg {
-    left: 33.33333%; }
-  .push-5-lg {
-    left: 41.66667%; }
-  .push-6-lg {
-    left: 50%; }
-  .push-7-lg {
-    left: 58.33333%; }
-  .push-8-lg {
-    left: 66.66667%; }
-  .push-9-lg {
-    left: 75%; }
-  .push-10-lg {
-    left: 83.33333%; }
-  .push-11-lg {
-    left: 91.66667%; }
-  .push-12-lg {
-    left: 100%; }
-  .offset-0-lg {
-    margin-left: 0%; }
-  .offset-1-lg {
-    margin-left: 8.33333%; }
-  .offset-2-lg {
-    margin-left: 16.66667%; }
-  .offset-3-lg {
-    margin-left: 25%; }
-  .offset-4-lg {
-    margin-left: 33.33333%; }
-  .offset-5-lg {
-    margin-left: 41.66667%; }
-  .offset-6-lg {
-    margin-left: 50%; }
-  .offset-7-lg {
-    margin-left: 58.33333%; }
-  .offset-8-lg {
-    margin-left: 66.66667%; }
-  .offset-9-lg {
-    margin-left: 75%; }
-  .offset-10-lg {
-    margin-left: 83.33333%; }
-  .offset-11-lg {
-    margin-left: 91.66667%; } }
-
-@media (min-width: 1500px) {
-  .col-xl {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%; }
-  .col-xl-auto {
-    flex: 0 0 auto;
-    width: auto; }
-  .col-1-xl {
-    flex: 0 0 8.33333%;
-    max-width: 8.33333%; }
-  .col-2-xl {
-    flex: 0 0 16.66667%;
-    max-width: 16.66667%; }
-  .col-3-xl {
-    flex: 0 0 25%;
-    max-width: 25%; }
-  .col-4-xl {
-    flex: 0 0 33.33333%;
-    max-width: 33.33333%; }
-  .col-5-xl {
-    flex: 0 0 41.66667%;
-    max-width: 41.66667%; }
-  .col-6-xl {
-    flex: 0 0 50%;
-    max-width: 50%; }
-  .col-7-xl {
-    flex: 0 0 58.33333%;
-    max-width: 58.33333%; }
-  .col-8-xl {
-    flex: 0 0 66.66667%;
-    max-width: 66.66667%; }
-  .col-9-xl {
-    flex: 0 0 75%;
-    max-width: 75%; }
-  .col-10-xl {
-    flex: 0 0 83.33333%;
-    max-width: 83.33333%; }
-  .col-11-xl {
-    flex: 0 0 91.66667%;
-    max-width: 91.66667%; }
-  .col-12-xl {
-    flex: 0 0 100%;
-    max-width: 100%; }
-  .pull-0-xl {
-    right: auto; }
-  .pull-1-xl {
-    right: 8.33333%; }
-  .pull-2-xl {
-    right: 16.66667%; }
-  .pull-3-xl {
-    right: 25%; }
-  .pull-4-xl {
-    right: 33.33333%; }
-  .pull-5-xl {
-    right: 41.66667%; }
-  .pull-6-xl {
-    right: 50%; }
-  .pull-7-xl {
-    right: 58.33333%; }
-  .pull-8-xl {
-    right: 66.66667%; }
-  .pull-9-xl {
-    right: 75%; }
-  .pull-10-xl {
-    right: 83.33333%; }
-  .pull-11-xl {
-    right: 91.66667%; }
-  .pull-12-xl {
-    right: 100%; }
-  .push-0-xl {
-    left: auto; }
-  .push-1-xl {
-    left: 8.33333%; }
-  .push-2-xl {
-    left: 16.66667%; }
-  .push-3-xl {
-    left: 25%; }
-  .push-4-xl {
-    left: 33.33333%; }
-  .push-5-xl {
-    left: 41.66667%; }
-  .push-6-xl {
-    left: 50%; }
-  .push-7-xl {
-    left: 58.33333%; }
-  .push-8-xl {
-    left: 66.66667%; }
-  .push-9-xl {
-    left: 75%; }
-  .push-10-xl {
-    left: 83.33333%; }
-  .push-11-xl {
-    left: 91.66667%; }
-  .push-12-xl {
-    left: 100%; }
-  .offset-0-xl {
-    margin-left: 0%; }
-  .offset-1-xl {
-    margin-left: 8.33333%; }
-  .offset-2-xl {
-    margin-left: 16.66667%; }
-  .offset-3-xl {
-    margin-left: 25%; }
-  .offset-4-xl {
-    margin-left: 33.33333%; }
-  .offset-5-xl {
-    margin-left: 41.66667%; }
-  .offset-6-xl {
-    margin-left: 50%; }
-  .offset-7-xl {
-    margin-left: 58.33333%; }
-  .offset-8-xl {
-    margin-left: 66.66667%; }
-  .offset-9-xl {
-    margin-left: 75%; }
-  .offset-10-xl {
-    margin-left: 83.33333%; }
-  .offset-11-xl {
-    margin-left: 91.66667%; } }


### PR DESCRIPTION
Brings some utilities over from pare_web that I think will be commonly used enough to be here.

- sizing utilities, such as `.width5`, `.height3-sm` and also some 100% utils like `.width-full` and `.height-full`.
- negative margin classes (e.g. `mtn3`)
- `.text-underline`
- `.flex-none`, for specifying that an item in a flexbox should not shrink or grow. Basscss has this class.

cc @sumul 

![sizing](https://user-images.githubusercontent.com/147870/28394083-718a78c8-6c9f-11e7-8b83-1094052e927f.gif)