### PR TITLE
Fix scss compilation in other projects

### DIFF
--- a/styles/_components.scss
+++ b/styles/_components.scss
@@ -1,8 +1,8 @@
-@import 'library/components/button/button';
-@import 'library/components/checkbox/checkbox';
-@import 'library/components/message/message';
-@import 'library/components/tab/tab';
+@import '../library/components/button/button';
+@import '../library/components/checkbox/checkbox';
+@import '../library/components/message/message';
+@import '../library/components/tab/tab';
 
 // Note: order matters for form utilities!
-@import 'library/components/text_input/text_input';
-@import 'library/components/form_group/form_group';
+@import '../library/components/text_input/text_input';
+@import '../library/components/form_group/form_group';

--- a/styles/_utilities.scss
+++ b/styles/_utilities.scss
@@ -1,6 +1,6 @@
-@import 'library/utilities/display/display';
-@import 'library/utilities/flexbox/flexbox';
-@import 'library/utilities/grid/grid';
-@import 'library/utilities/sizing/sizing';
-@import 'library/utilities/spacing/spacing';
-@import 'library/utilities/typography/typography';
+@import '../library/utilities/display/display';
+@import '../library/utilities/flexbox/flexbox';
+@import '../library/utilities/grid/grid';
+@import '../library/utilities/sizing/sizing';
+@import '../library/utilities/spacing/spacing';
+@import '../library/utilities/typography/typography';


### PR DESCRIPTION
@iqnivek I changed these import paths when I did the component reorg, without realizing that it would break things when another project (like pare_web) tries to compile the css.