### PR TITLE
Remove .Checkbox—is-disabled modifier

### DIFF
--- a/library/components/checkbox/README.md
+++ b/library/components/checkbox/README.md
@@ -24,6 +24,5 @@ Passing a prop that is not a legal DOM attribute will cause React to trigger an 
 | `Checkbox--small[-breakpoint]` | false | true | Responsive breakpoint token optional |
 | `Checkbox--medium[-breakpoint]` | true | true | Responsive breakpoint token optional |
 | `Checkbox--large[-breakpoint]` | false | true | Responsive breakpoint token optional |
-| `Checkbox--is-disabled` | false | false | If the component has a truthy `disabled` prop, this modifier is applied automatically. |
 
 For the responsive classes, append a responsive breakpoint token to apply the associated sizing styles at that breakpoint and up. For example, `.Checkbox--small .Checkbox--medium-sm .Checkbox--large-md` will give you a small size checkbox on `xs` screens, medium on `sm` screens, and large on `md` screens and up.

--- a/library/components/checkbox/checkbox.jsx
+++ b/library/components/checkbox/checkbox.jsx
@@ -4,11 +4,7 @@ const classes = require('classnames');
 function Checkbox(props) {
   const { className, label, ...htmlProps } = props;
   return (
-    <label className={classes(
-      className, 
-      'Checkbox', 
-      { 'Checkbox--is-disabled': htmlProps.disabled }
-    )}>
+    <label className={classes(className, 'Checkbox')}>
       <input type="checkbox" className="Checkbox__input" { ...htmlProps } />
       <span className="Checkbox__indicator"></span>
       <span className="Checkbox__label">{ props.label }</span>

--- a/library/components/checkbox/checkbox.spec.jsx
+++ b/library/components/checkbox/checkbox.spec.jsx
@@ -17,7 +17,7 @@ describe('Checkbox', function () {
     expect(inputProps.type).to.equal('checkbox');
   });
 
-  it('should pass HTML attributes to input element and apply disabled class', function () {
+  it('should pass HTML attributes to input element', function () {
     const wrapper = shallow(
       <Checkbox
         className="className"
@@ -30,7 +30,6 @@ describe('Checkbox', function () {
     );
 
     const wrapperProps = wrapper.find('label').props();
-    expect(wrapperProps.className).to.equal('className Checkbox Checkbox--is-disabled');
 
     const inputProps = wrapper.find('input').props();
     expect(inputProps.className).to.equal('Checkbox__input');


### PR DESCRIPTION
We ended up just using the `:disabled` state on the checkbox element to apply the disabled style, which I think was the right call, because:

- we also apply styling with `:checked` and `:active`
- it seems unlikely that we'd want to apply the disabled style without actually disabling the checkbox (and that would probably be confusing for the user anyway)

cc @iqnivek 