### PR TITLE
Don’t re-render unless actually need to apply active class

### DIFF
--- a/library/components/button/anchor_button.jsx
+++ b/library/components/button/anchor_button.jsx
@@ -36,7 +36,9 @@ class AnchorButton extends React.Component {
   handleKeyDown(event) {
     if (isSpacebarEvent(event)) {
       event.preventDefault();
-      this.setState({ spacePressed: true });
+      if (!this.state.spacePressed) {
+        this.setState({ spacePressed: true });
+      }
     }
   }
 


### PR DESCRIPTION
@gelsto 

Didn't realize that calling setState without any actual changes will call `render` again anyway ... if you hold down spacebar, the keydown event can be triggered many, many times. This will avoid re-rendering many, many times.