### PR TITLE
Feature/use cursor not allowed for disabled inputs

### DIFF
--- a/library/components/button/README.md
+++ b/library/components/button/README.md
@@ -26,7 +26,6 @@ Valid HTML attributes and additional event handlers for the `button` or `a` elem
 | `Button--small` | false | true | |
 | `Button--medium` | true | true | |
 | `Button--large` | false | true | |
-| `Button--is-disabled` | false | false | If the component has a truthy `disabled` prop, this modifier is applied automatically. |
 | `Button--primary` | false | false | |
 | `Button--danger` | false | false | |
 | `Button--link` | false | false | |

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -88,17 +88,20 @@
 // Danger button
 // -------------
 
-.Button--danger .Button__control {
-  @include reversed-text;
-  background: $red;
+.Button--danger {
+  .Button__control {
+    @include reversed-text;
+    background: $red;
 
-  &:hover,
-  &:focus {
-    background: darken($red, 5);
-    color: $white;
+    &:hover,
+    &:focus {
+      background: darken($red, 5);
+      color: $white;
+    }
   }
 
-  &:active {
+  .Button__control:active,
+  &.Button--is-active .Button__control {
     background: darken($red, 11);
   }
 }
@@ -106,19 +109,22 @@
 // Primary button
 // --------------
 
-.Button--primary .Button__control {
-  @include depth(4);
-  @include reversed-text($font-weight: $font-weight-bold);
-  background: $blue;
+.Button--primary {
+  .Button__control {
+    @include depth(4);
+    @include reversed-text($font-weight: $font-weight-bold);
+    background: $blue;
 
-  &:hover,
-  &:focus {
-    @include depth(7);
-    background: darken($blue, 5);
-    color: $white;
+    &:hover,
+    &:focus {
+      @include depth(7);
+      background: darken($blue, 5);
+      color: $white;
+    }
   }
 
-  &:active {
+  .Button__control:active,
+  &.Button--is-active .Button__control {
     @include depth(0);
     background: darken($blue, 11);
   }
@@ -128,16 +134,19 @@
 // -----------------
 
 .Button--link .Button__control {
-  background: transparent;
-  color: $blue;
+  .Button__control {
+    background: transparent;
+    color: $blue;
 
-  &:hover,
-  &:focus {
-    background: rgba($black, .05);
-    color: $blue-300;
+    &:hover,
+    &:focus {
+      background: rgba($black, .05);
+      color: $blue-300;
+    }
   }
 
-  &:active {
+  .Button__control:active,
+  &.Button--is-active .Button__control {
     background: rgba($black, .11);
     color: $blue-400;
   }

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -60,15 +60,6 @@
   transition-duration: .08s;
 }
 
-.Button--is-disabled {
-  cursor: not-allowed;
-
-  .Button__control {
-    opacity: $alpha-600;
-    pointer-events: none;
-  }
-}
-
 .Button__control:active,
 .Button--is-active .Button__control,
 .Button--is-active .Button__control:focus {
@@ -78,10 +69,20 @@
   transition-duration: 0s;
 }
 
-
 // Allow focus indicator when tabbing but hide it if clicking
-.Button__control:active:focus {
+.Button__control:active:focus,
+.Button--is-active .Button__control:focus, {
   outline: 0;
+}
+
+.Button__control:disabled,
+.Button--is-disabled .Button__control {
+  opacity: $alpha-600;
+  pointer-events: none;
+}
+
+.Button--is-disabled {
+  cursor: not-allowed;
 }
 
 // Danger button

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -1,19 +1,21 @@
 // scss-lint:disable SelectorFormat ElsePlacement
 
 @mixin button-sizer($size: 'medium') {
-  @if $size == 'small' {
-    font-size: $font-size-2;
-    padding: modular-scale-px(-6) modular-scale-px(-1) modular-scale-px(-5);
-  }
+  .Button__control {
+    @if $size == 'small' {
+      font-size: $font-size-2;
+      padding: modular-scale-px(-6) modular-scale-px(-1) modular-scale-px(-5);
+    }
 
-  @else if $size == 'medium' {
-    font-size: $font-size-3;
-    padding: modular-scale-px(-3) modular-scale-px(2) modular-scale-px(-2);
-  }
+    @else if $size == 'medium' {
+      font-size: $font-size-3;
+      padding: modular-scale-px(-3) modular-scale-px(2) modular-scale-px(-2);
+    }
 
-  @else if $size == 'large' {
-    font-size: $font-size-4;
-    padding: modular-scale-px(0) modular-scale-px(4) modular-scale-px(1);
+    @else if $size == 'large' {
+      font-size: $font-size-4;
+      padding: modular-scale-px(0) modular-scale-px(4) modular-scale-px(1);
+    }
   }
 }
 
@@ -21,8 +23,12 @@
 // ------------
 
 .Button {
-  // scss-lint:disable PropertySortOrder
   @include button-sizer;
+  display: inline-block;
+}
+
+.Button__control {
+  // scss-lint:disable PropertySortOrder
   background: rgba($black, $alpha-200);
   border: 0;
   border-radius: $border-radius;
@@ -44,8 +50,8 @@
   user-select: none;
 }
 
-.Button:hover,
-.Button:focus {
+.Button__control:hover,
+.Button__control:focus {
   @include depth(4);
   background: rgba($black, $alpha-200 + .05);
   color: $text-color-primary;
@@ -54,30 +60,34 @@
   transition-duration: .08s;
 }
 
-.Button:disabled,
 .Button--is-disabled {
-  opacity: $alpha-600;
-  pointer-events: none;
+  cursor: not-allowed;
+
+  .Button__control {
+    opacity: $alpha-600;
+    pointer-events: none;
+  }
 }
 
-.Button:active,
-.Button--is-active,
-.Button--is-active:focus {
+.Button__control:active,
+.Button--is-active .Button__control,
+.Button--is-active .Button__control:focus {
   @include depth(0);
   background: rgba($black, $alpha-200 + .11);
   transform: translateY(0) scaleX(1) scaleY(1);
   transition-duration: 0s;
 }
 
+
 // Allow focus indicator when tabbing but hide it if clicking
-.Button:active:focus {
+.Button__control:active:focus {
   outline: 0;
 }
 
 // Danger button
 // -------------
 
-.Button--danger {
+.Button--danger .Button__control {
   @include reversed-text;
   background: $red;
 
@@ -87,8 +97,7 @@
     color: $white;
   }
 
-  &:active,
-  &.Button--is-active {
+  &:active {
     background: darken($red, 11);
   }
 }
@@ -96,7 +105,7 @@
 // Primary button
 // --------------
 
-.Button--primary {
+.Button--primary .Button__control {
   @include depth(4);
   @include reversed-text($font-weight: $font-weight-bold);
   background: $blue;
@@ -108,8 +117,7 @@
     color: $white;
   }
 
-  &:active,
-  &.Button--is-active {
+  &:active {
     @include depth(0);
     background: darken($blue, 11);
   }
@@ -118,7 +126,7 @@
 // Link style button
 // -----------------
 
-.Button--link {
+.Button--link .Button__control {
   background: transparent;
   color: $blue;
 
@@ -128,8 +136,7 @@
     color: $blue-300;
   }
 
-  &:active,
-  &.Button--is-active {
+  &:active {
     background: rgba($black, .11);
     color: $blue-400;
   }
@@ -146,22 +153,21 @@
 // Or this: <body ontouchstart="">
 
 @media (pointer: coarse), (any-pointer: coarse) {
-  .Button:hover {
+  .Button__control:hover {
     @include depth(0);
     background: rgba($black, $alpha-200 + .11);
     transform: translateY(1px) scaleX(.985) scaleY(.985);
   }
 
-  .Button--danger:hover {
+  .Button--danger .Button__control:hover {
     background: darken($red, 11);
   }
 
-  .Button--primary:hover {
-    @include depth(0);
+  .Button--primary .Button__control:hover {
     background: darken($blue, 11);
   }
 
-  .Button--link:hover {
+  .Button--link .Button__control:hover {
     background: rgba($black, .11);
     color: $blue-400;
   }

--- a/library/components/button/anchor_button.jsx
+++ b/library/components/button/anchor_button.jsx
@@ -54,13 +54,18 @@ class AnchorButton extends React.Component {
     const { children, className, disabled, tabIndex, ...htmlProps } = this.props;
 
     return (
-      <div className={classes(className, { 'Button--is-active': this.state.spacePressed })}>
+      <div
+        className={classes(className, {
+          'Button--is-active': this.state.spacePressed,
+        })}
+      >
         <a
           {...htmlProps}
           className="Button__control"
           onClick={this.handleAnchorClick}
           onKeyDown={this.handleKeyDown}
           onKeyUp={this.handleKeyUp}
+          ref={(element) => { this.element = element }}
           role="button"
           tabIndex={disabled ? -1 : tabIndex}
         >

--- a/library/components/button/anchor_button.jsx
+++ b/library/components/button/anchor_button.jsx
@@ -51,21 +51,22 @@ class AnchorButton extends React.Component {
   }
 
   render() {
-    const { className, children, disabled, tabIndex, ...htmlProps } = this.props;
+    const { children, className, disabled, tabIndex, ...htmlProps } = this.props;
 
     return (
-      <a
-        {...htmlProps}
-        ref={(element) => { this.element = element }}
-        className={classes(className, { 'Button--is-active': this.state.spacePressed })}
-        onClick={this.handleAnchorClick}
-        onKeyDown={this.handleKeyDown}
-        onKeyUp={this.handleKeyUp}
-        role="button"
-        tabIndex={disabled ? -1 : tabIndex}
-      >
-        {children}
-      </a>
+      <div className={classes(className, { 'Button--is-active': this.state.spacePressed })}>
+        <a
+          {...htmlProps}
+          className="Button__control"
+          onClick={this.handleAnchorClick}
+          onKeyDown={this.handleKeyDown}
+          onKeyUp={this.handleKeyUp}
+          role="button"
+          tabIndex={disabled ? -1 : tabIndex}
+        >
+          {children}
+        </a>
+      </div>
     );
   }
 }

--- a/library/components/button/true_button.jsx
+++ b/library/components/button/true_button.jsx
@@ -14,14 +14,17 @@ function validateType(type) {
 }
 
 function TrueButton(props) {
-  const { children, type, ...htmlProps } = props;
+  const { children, className, type, ...htmlProps } = props;
   return (
-    <button
-      {...htmlProps}
-      type={validateType(type)}
-    >
-      {children}
-    </button>
+    <div className={className}>
+      <button
+        {...htmlProps}
+        className="Button__control"
+        type={validateType(type)}
+      >
+        {children}
+      </button>
+    </div>
   );
 }
 

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -123,6 +123,10 @@
   user-select: none;
 }
 
+.Checkbox--is-disabled {
+  cursor: not-allowed;
+}
+
 @if $enable-responsive-form-components {
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {

--- a/library/components/checkbox/checkbox.jsx
+++ b/library/components/checkbox/checkbox.jsx
@@ -4,7 +4,14 @@ import classes from 'classnames';
 function Checkbox(props) {
   const { className, label, ...htmlProps } = props;
   return (
-    <label className={classes(className, 'Checkbox', { 'Checkbox--is-disabled': htmlProps.disabled })}>
+    <label
+      className={classes(className, 'Checkbox', {
+        // Most of the styling for disabled checkboxes is tied to the :disabled input state --
+        // adding this modifier on the root element enables the `not-allowed` cursor for
+        // child elements with `pointer-events: none`
+        'Checkbox--is-disabled': htmlProps.disabled,
+      })}
+    >
       <input type="checkbox" className="Checkbox__input" {...htmlProps} />
       <span className="Checkbox__indicator" />
       <span className="Checkbox__label">{ props.label }</span>

--- a/library/components/checkbox/checkbox.jsx
+++ b/library/components/checkbox/checkbox.jsx
@@ -4,7 +4,7 @@ import classes from 'classnames';
 function Checkbox(props) {
   const { className, label, ...htmlProps } = props;
   return (
-    <label className={classes(className, 'Checkbox')}>
+    <label className={classes(className, 'Checkbox', { 'Checkbox--is-disabled': htmlProps.disabled })}>
       <input type="checkbox" className="Checkbox__input" {...htmlProps} />
       <span className="Checkbox__indicator" />
       <span className="Checkbox__label">{ props.label }</span>

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -145,6 +145,10 @@
   }
 }
 
+.Radio--is-disabled {
+  cursor: not-allowed;
+}
+
 @if $enable-responsive-form-components {
   @each $breakpoint in map-keys($grid-breakpoints) {
     @include media-breakpoint-up($breakpoint) {

--- a/library/components/radio/radio.jsx
+++ b/library/components/radio/radio.jsx
@@ -4,7 +4,7 @@ import classes from 'classnames';
 function Radio(props) {
   const { className, children, ...inputProps } = props;
   return (
-    <label className={classes(className, 'Radio')}>
+    <label className={classes(className, 'Radio', { 'Radio--is-disabled': inputProps.disabled })}>
       <input type="radio" className="Radio__input" {...inputProps} />
       <span className="Radio__indicator" />
       <span className="Radio__label">{ children }</span>

--- a/library/components/radio/radio.jsx
+++ b/library/components/radio/radio.jsx
@@ -4,7 +4,14 @@ import classes from 'classnames';
 function Radio(props) {
   const { className, children, ...inputProps } = props;
   return (
-    <label className={classes(className, 'Radio', { 'Radio--is-disabled': inputProps.disabled })}>
+    <label
+      className={classes(className, 'Radio', {
+        // Most of the styling for disabled radios is tied to the :disabled input state --
+        // adding this modifier on the root element enables the `not-allowed` cursor for
+        // child elements with `pointer-events: none`
+        'Radio--is-disabled': inputProps.disabled,
+      })}
+    >
       <input type="radio" className="Radio__input" {...inputProps} />
       <span className="Radio__indicator" />
       <span className="Radio__label">{ children }</span>

--- a/library/components/text_input/README.md
+++ b/library/components/text_input/README.md
@@ -34,5 +34,4 @@ Valid HTML attributes and event handlers for the input element may be safely pas
 | `TextInput--small` | false | true | |
 | `TextInput--medium` | true | true | |
 | `TextInput--large` | false | true | |
-| `TextInput--is-disabled` | false | false | If the component has a truthy `disabled` prop, this modifier is applied automatically. |
 | `TextInput--has-error` | false | false | |

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -55,6 +55,7 @@
   background: $gray-200;
   border-color: $gray-200;
   color: $text-color-hint;
+  cursor: not-allowed;
   opacity: 1; // some browsers (e.g. iOS Safari) reduce opacity
 }
 

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -50,8 +50,7 @@
 }
 
 .TextInput:disabled,
-.TextInput[readonly],
-.TextInput--is-disabled {
+.TextInput[readonly] {
   background: $gray-200;
   border-color: $gray-200;
   color: $text-color-hint;

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -42,8 +42,7 @@
   }
 }
 
-.TextInput:focus,
-.TextInput--is-focused {
+.TextInput:focus {
   border-color: $blue-100;
   box-shadow: 0 0 11px rgba($blue-100, $alpha-500);
   outline: 0;
@@ -62,8 +61,7 @@
 .FormGroup--has-error .TextInput {
   border-color: $red;
 
-  &.TextInput:focus,
-  &.TextInput--is-focused {
+  &.TextInput:focus {
     box-shadow: 0 0 11px rgba($red-100, $alpha-600);
   }
 }

--- a/library/components/text_input/text_input.jsx
+++ b/library/components/text_input/text_input.jsx
@@ -30,9 +30,7 @@ function TextInput(props) {
   const { className, type, ...htmlProps } = props;
   return (
     <input
-      className={classes(className, 'TextInput', {
-        'TextInput--is-disabled': htmlProps.disabled,
-      })}
+      className={classes(className, 'TextInput')}
       type={validateType(type)}
       {...htmlProps}
     />

--- a/styles/_utilities.scss
+++ b/styles/_utilities.scss
@@ -4,3 +4,8 @@
 @import '../library/utilities/sizing/sizing';
 @import '../library/utilities/spacing/spacing';
 @import '../library/utilities/typography/typography';
+
+// scss-lint:disable ImportantRule
+.cursor-not-allowed {
+  cursor: not-allowed !important;
+}

--- a/styles/_utilities.scss
+++ b/styles/_utilities.scss
@@ -4,8 +4,3 @@
 @import '../library/utilities/sizing/sizing';
 @import '../library/utilities/spacing/spacing';
 @import '../library/utilities/typography/typography';
-
-// scss-lint:disable ImportantRule
-.cursor-not-allowed {
-  cursor: not-allowed !important;
-}

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -439,7 +439,8 @@ hr {
   background: #ee3548;
   color: #fff; }
 
-.Button--danger .Button__control:active {
+.Button--danger .Button__control:active,
+.Button--danger.Button--is-active .Button__control {
   background: #ec192e; }
 
 .Button--primary .Button__control {
@@ -454,19 +455,21 @@ hr {
   background: #14a5c9;
   color: #fff; }
 
-.Button--primary .Button__control:active {
+.Button--primary .Button__control:active,
+.Button--primary.Button--is-active .Button__control {
   box-shadow: none;
   background: #118ead; }
 
-.Button--link .Button__control {
+.Button--link .Button__control .Button__control {
   background: transparent;
   color: #16b8e0; }
 
-.Button--link .Button__control:hover, .Button--link .Button__control:focus {
+.Button--link .Button__control .Button__control:hover, .Button--link .Button__control .Button__control:focus {
   background: rgba(0, 0, 0, 0.05);
   color: #008ab3; }
 
-.Button--link .Button__control:active {
+.Button--link .Button__control .Button__control:active,
+.Button--link .Button__control.Button--is-active .Button__control {
   background: rgba(0, 0, 0, 0.11);
   color: #005678; }
 

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -167,18 +167,21 @@ a {
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
-  a:hover {
-    color: #008ab3;
-    text-decoration: underline; }
+
+a:hover {
+  color: #008ab3;
+  text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
   color: inherit;
   text-decoration: none; }
-  a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-    color: inherit;
-    text-decoration: none; }
-  a:not([href]):not([tabindex]):focus {
-    outline: 0; }
+
+a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
+  color: inherit;
+  text-decoration: none; }
+
+a:not([href]):not([tabindex]):focus {
+  outline: 0; }
 
 pre,
 code,
@@ -375,9 +378,10 @@ hr {
 
 .Button {
   display: inline-block; }
-  .Button .Button__control {
-    font-size: 16px;
-    padding: 11px 21px 12px; }
+
+.Button .Button__control {
+  font-size: 16px;
+  padding: 11px 21px 12px; }
 
 .Button__control {
   background: rgba(0, 0, 0, 0.07);
@@ -406,12 +410,6 @@ hr {
   transform: translateY(-2.25px) scaleX(1.015) scaleY(1.015);
   transition-duration: .08s; }
 
-.Button--is-disabled {
-  cursor: not-allowed; }
-  .Button--is-disabled .Button__control {
-    opacity: 0.54;
-    pointer-events: none; }
-
 .Button__control:active,
 .Button--is-active .Button__control,
 .Button--is-active .Button__control:focus {
@@ -420,18 +418,29 @@ hr {
   transform: translateY(0) scaleX(1) scaleY(1);
   transition-duration: 0s; }
 
-.Button__control:active:focus {
+.Button__control:active:focus,
+.Button--is-active .Button__control:focus {
   outline: 0; }
+
+.Button__control:disabled,
+.Button--is-disabled .Button__control {
+  opacity: 0.54;
+  pointer-events: none; }
+
+.Button--is-disabled {
+  cursor: not-allowed; }
 
 .Button--danger .Button__control {
   color: #fff;
   font-weight: normal;
   background: #f04d5d; }
-  .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
-    background: #ee3548;
-    color: #fff; }
-  .Button--danger .Button__control:active {
-    background: #ec192e; }
+
+.Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
+  background: #ee3548;
+  color: #fff; }
+
+.Button--danger .Button__control:active {
+  background: #ec192e; }
 
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
@@ -439,23 +448,27 @@ hr {
   font-weight: bold;
   -webkit-font-smoothing: antialiased;
   background: #16b8e0; }
-  .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
-    background: #14a5c9;
-    color: #fff; }
-  .Button--primary .Button__control:active {
-    box-shadow: none;
-    background: #118ead; }
+
+.Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
+  background: #14a5c9;
+  color: #fff; }
+
+.Button--primary .Button__control:active {
+  box-shadow: none;
+  background: #118ead; }
 
 .Button--link .Button__control {
   background: transparent;
   color: #16b8e0; }
-  .Button--link .Button__control:hover, .Button--link .Button__control:focus {
-    background: rgba(0, 0, 0, 0.05);
-    color: #008ab3; }
-  .Button--link .Button__control:active {
-    background: rgba(0, 0, 0, 0.11);
-    color: #005678; }
+
+.Button--link .Button__control:hover, .Button--link .Button__control:focus {
+  background: rgba(0, 0, 0, 0.05);
+  color: #008ab3; }
+
+.Button--link .Button__control:active {
+  background: rgba(0, 0, 0, 0.11);
+  color: #005678; }
 
 @media (pointer: coarse), (any-pointer: coarse) {
   .Button__control:hover {
@@ -535,43 +548,52 @@ hr {
   display: inline-block;
   margin: 0;
   position: relative; }
-  .Checkbox .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+
+.Checkbox .Checkbox__indicator {
+  background-position: 1px 2px;
+  background-size: 10px 9px;
+  height: 16px;
+  top: 1px;
+  width: 16px; }
 
 .Checkbox__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-  .Checkbox__input:focus ~ .Checkbox__indicator {
-    border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
-  .Checkbox__input:active ~ .Checkbox__indicator {
-    background-color: #f9f9f9;
-    border-color: #c1c1c1; }
-  .Checkbox__input:checked ~ .Checkbox__indicator {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-    background-color: #232323;
-    border-color: #232323; }
-  .Checkbox__input:checked:focus ~ .Checkbox__indicator {
-    border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
-  .Checkbox__input:checked:active ~ .Checkbox__indicator {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-    background-color: #232323;
-    border-color: #232323; }
-  .Checkbox__input:disabled ~ .Checkbox__indicator,
-  .Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
-    background-color: #eee;
-    border-color: #eee; }
-  .Checkbox__input:disabled:checked ~ .Checkbox__indicator,
-  .Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
-    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
-  .Checkbox__input:disabled ~ .Checkbox__label {
-    color: rgba(0, 0, 0, 0.54); }
+
+.Checkbox__input:focus ~ .Checkbox__indicator {
+  border-color: #7feaff;
+  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+
+.Checkbox__input:active ~ .Checkbox__indicator {
+  background-color: #f9f9f9;
+  border-color: #c1c1c1; }
+
+.Checkbox__input:checked ~ .Checkbox__indicator {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+  background-color: #232323;
+  border-color: #232323; }
+
+.Checkbox__input:checked:focus ~ .Checkbox__indicator {
+  border-color: #232323;
+  box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+
+.Checkbox__input:checked:active ~ .Checkbox__indicator {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+  background-color: #232323;
+  border-color: #232323; }
+
+.Checkbox__input:disabled ~ .Checkbox__indicator,
+.Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
+  background-color: #eee;
+  border-color: #eee; }
+
+.Checkbox__input:disabled:checked ~ .Checkbox__indicator,
+.Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
+
+.Checkbox__input:disabled ~ .Checkbox__label {
+  color: rgba(0, 0, 0, 0.54); }
 
 .Checkbox__indicator {
   background-color: #fff;
@@ -592,12 +614,13 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 23px; }
-  .Checkbox--medium .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+
+.Checkbox--medium .Checkbox__indicator {
+  background-position: 1px 2px;
+  background-size: 10px 9px;
+  height: 16px;
+  top: 1px;
+  width: 16px; }
 
 .Checkbox--small {
   font-size: 12px;
@@ -605,12 +628,13 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 21px; }
-  .Checkbox--small .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+
+.Checkbox--small .Checkbox__indicator {
+  background-position: 1px 1px;
+  background-size: 8px 8px;
+  height: 14px;
+  top: 1px;
+  width: 14px; }
 
 .Checkbox--large {
   font-size: 18px;
@@ -618,12 +642,13 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 32px; }
-  .Checkbox--large .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; }
+
+.Checkbox--large .Checkbox__indicator {
+  background-position: 2px 3px;
+  background-size: 14px 11px;
+  height: 21px;
+  top: 2px;
+  width: 21px; }
 
 @media (min-width: 600px) {
   .Checkbox--medium-sm {
@@ -632,36 +657,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-sm .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-sm .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-sm {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-sm .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-sm .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-sm {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-sm .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-sm .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 @media (min-width: 900px) {
   .Checkbox--medium-md {
@@ -670,36 +695,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-md .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-md .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-md {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-md .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-md .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-md {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-md .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-md .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 @media (min-width: 1200px) {
   .Checkbox--medium-lg {
@@ -708,36 +733,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-lg .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-lg .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-lg {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-lg .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-lg .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-lg {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-lg .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-lg .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 @media (min-width: 1500px) {
   .Checkbox--medium-xl {
@@ -746,36 +771,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-    .Checkbox--medium-xl .Checkbox__indicator {
-      background-position: 1px 2px;
-      background-size: 10px 9px;
-      height: 16px;
-      top: 1px;
-      width: 16px; }
+  .Checkbox--medium-xl .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
   .Checkbox--small-xl {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Checkbox--small-xl .Checkbox__indicator {
-      background-position: 1px 1px;
-      background-size: 8px 8px;
-      height: 14px;
-      top: 1px;
-      width: 14px; }
+  .Checkbox--small-xl .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
   .Checkbox--large-xl {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-    .Checkbox--large-xl .Checkbox__indicator {
-      background-position: 2px 3px;
-      background-size: 14px 11px;
-      height: 21px;
-      top: 2px;
-      width: 21px; } }
+  .Checkbox--large-xl .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; } }
 
 .Message {
   background-color: #eee;
@@ -803,49 +828,61 @@ hr {
   display: inline-block;
   margin: 0;
   position: relative; }
-  .Radio .Radio__indicator {
-    height: 16px;
-    top: 1px;
-    width: 16px; }
-    .Radio .Radio__indicator::after {
-      height: 6px;
-      left: 3px;
-      top: 3px;
-      width: 6px; }
+
+.Radio .Radio__indicator {
+  height: 16px;
+  top: 1px;
+  width: 16px; }
+
+.Radio .Radio__indicator::after {
+  height: 6px;
+  left: 3px;
+  top: 3px;
+  width: 6px; }
 
 .Radio__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-  .Radio__input:focus ~ .Radio__indicator {
-    border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
-  .Radio__input:active ~ .Radio__indicator {
-    background-color: #f9f9f9;
-    border-color: #c1c1c1; }
-  .Radio__input:checked ~ .Radio__indicator {
-    background-color: #232323;
-    border-color: #232323;
-    color: #fff; }
-    .Radio__input:checked ~ .Radio__indicator::after {
-      display: block; }
-  .Radio__input:checked:focus ~ .Radio__indicator {
-    border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
-  .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
-    background-color: #232323;
-    border-color: #232323; }
-    .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator::after {
-      opacity: 0.54; }
-  .Radio__input:disabled ~ .Radio__indicator,
-  .Radio__input:disabled:active ~ .Radio__indicator, .Radio__input:disabled:checked:active {
-    background-color: #eee;
-    border-color: #eee; }
-  .Radio__input:disabled:checked ~ .Radio__indicator::after,
-  .Radio__input:disabled:checked:active ~ .Radio__indicator::after {
-    background-color: #c1c1c1; }
-  .Radio__input:disabled ~ .Radio__label {
-    color: rgba(0, 0, 0, 0.54); }
+
+.Radio__input:focus ~ .Radio__indicator {
+  border-color: #7feaff;
+  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+
+.Radio__input:active ~ .Radio__indicator {
+  background-color: #f9f9f9;
+  border-color: #c1c1c1; }
+
+.Radio__input:checked ~ .Radio__indicator {
+  background-color: #232323;
+  border-color: #232323;
+  color: #fff; }
+
+.Radio__input:checked ~ .Radio__indicator::after {
+  display: block; }
+
+.Radio__input:checked:focus ~ .Radio__indicator {
+  border-color: #232323;
+  box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+
+.Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
+  background-color: #232323;
+  border-color: #232323; }
+
+.Radio__input:checked:active:not(:disabled) ~ .Radio__indicator::after {
+  opacity: 0.54; }
+
+.Radio__input:disabled ~ .Radio__indicator,
+.Radio__input:disabled:active ~ .Radio__indicator, .Radio__input:disabled:checked:active {
+  background-color: #eee;
+  border-color: #eee; }
+
+.Radio__input:disabled:checked ~ .Radio__indicator::after,
+.Radio__input:disabled:checked:active ~ .Radio__indicator::after {
+  background-color: #c1c1c1; }
+
+.Radio__input:disabled ~ .Radio__label {
+  color: rgba(0, 0, 0, 0.54); }
 
 .Radio__indicator {
   background-color: #fff;
@@ -855,12 +892,13 @@ hr {
   pointer-events: none;
   position: absolute;
   user-select: none; }
-  .Radio__indicator::after {
-    background-color: #fff;
-    border-radius: 50%;
-    content: '';
-    display: none;
-    position: absolute; }
+
+.Radio__indicator::after {
+  background-color: #fff;
+  border-radius: 50%;
+  content: '';
+  display: none;
+  position: absolute; }
 
 .Radio--is-disabled {
   cursor: not-allowed; }
@@ -871,15 +909,17 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 19px; }
-  .Radio--small .Radio__indicator {
-    height: 14px;
-    top: 1px;
-    width: 14px; }
-    .Radio--small .Radio__indicator::after {
-      height: 6px;
-      left: 2px;
-      top: 2px;
-      width: 6px; }
+
+.Radio--small .Radio__indicator {
+  height: 14px;
+  top: 1px;
+  width: 14px; }
+
+.Radio--small .Radio__indicator::after {
+  height: 6px;
+  left: 2px;
+  top: 2px;
+  width: 6px; }
 
 .Radio--medium {
   font-size: 14px;
@@ -887,15 +927,17 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 21px; }
-  .Radio--medium .Radio__indicator {
-    height: 16px;
-    top: 1px;
-    width: 16px; }
-    .Radio--medium .Radio__indicator::after {
-      height: 6px;
-      left: 3px;
-      top: 3px;
-      width: 6px; }
+
+.Radio--medium .Radio__indicator {
+  height: 16px;
+  top: 1px;
+  width: 16px; }
+
+.Radio--medium .Radio__indicator::after {
+  height: 6px;
+  left: 3px;
+  top: 3px;
+  width: 6px; }
 
 .Radio--large {
   font-size: 18px;
@@ -903,15 +945,17 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 28px; }
-  .Radio--large .Radio__indicator {
-    height: 21px;
-    top: 2px;
-    width: 21px; }
-    .Radio--large .Radio__indicator::after {
-      height: 7px;
-      left: 5px;
-      top: 5px;
-      width: 7px; }
+
+.Radio--large .Radio__indicator {
+  height: 21px;
+  top: 2px;
+  width: 21px; }
+
+.Radio--large .Radio__indicator::after {
+  height: 7px;
+  left: 5px;
+  top: 5px;
+  width: 7px; }
 
 @media (min-width: 600px) {
   .Radio--small-sm {
@@ -920,45 +964,45 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-    .Radio--small-sm .Radio__indicator {
-      height: 14px;
-      top: 1px;
-      width: 14px; }
-      .Radio--small-sm .Radio__indicator::after {
-        height: 6px;
-        left: 2px;
-        top: 2px;
-        width: 6px; }
+  .Radio--small-sm .Radio__indicator {
+    height: 14px;
+    top: 1px;
+    width: 14px; }
+  .Radio--small-sm .Radio__indicator::after {
+    height: 6px;
+    left: 2px;
+    top: 2px;
+    width: 6px; }
   .Radio--medium-sm {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Radio--medium-sm .Radio__indicator {
-      height: 16px;
-      top: 1px;
-      width: 16px; }
-      .Radio--medium-sm .Radio__indicator::after {
-        height: 6px;
-        left: 3px;
-        top: 3px;
-        width: 6px; }
+  .Radio--medium-sm .Radio__indicator {
+    height: 16px;
+    top: 1px;
+    width: 16px; }
+  .Radio--medium-sm .Radio__indicator::after {
+    height: 6px;
+    left: 3px;
+    top: 3px;
+    width: 6px; }
   .Radio--large-sm {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-    .Radio--large-sm .Radio__indicator {
-      height: 21px;
-      top: 2px;
-      width: 21px; }
-      .Radio--large-sm .Radio__indicator::after {
-        height: 7px;
-        left: 5px;
-        top: 5px;
-        width: 7px; } }
+  .Radio--large-sm .Radio__indicator {
+    height: 21px;
+    top: 2px;
+    width: 21px; }
+  .Radio--large-sm .Radio__indicator::after {
+    height: 7px;
+    left: 5px;
+    top: 5px;
+    width: 7px; } }
 
 @media (min-width: 900px) {
   .Radio--small-md {
@@ -967,45 +1011,45 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-    .Radio--small-md .Radio__indicator {
-      height: 14px;
-      top: 1px;
-      width: 14px; }
-      .Radio--small-md .Radio__indicator::after {
-        height: 6px;
-        left: 2px;
-        top: 2px;
-        width: 6px; }
+  .Radio--small-md .Radio__indicator {
+    height: 14px;
+    top: 1px;
+    width: 14px; }
+  .Radio--small-md .Radio__indicator::after {
+    height: 6px;
+    left: 2px;
+    top: 2px;
+    width: 6px; }
   .Radio--medium-md {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Radio--medium-md .Radio__indicator {
-      height: 16px;
-      top: 1px;
-      width: 16px; }
-      .Radio--medium-md .Radio__indicator::after {
-        height: 6px;
-        left: 3px;
-        top: 3px;
-        width: 6px; }
+  .Radio--medium-md .Radio__indicator {
+    height: 16px;
+    top: 1px;
+    width: 16px; }
+  .Radio--medium-md .Radio__indicator::after {
+    height: 6px;
+    left: 3px;
+    top: 3px;
+    width: 6px; }
   .Radio--large-md {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-    .Radio--large-md .Radio__indicator {
-      height: 21px;
-      top: 2px;
-      width: 21px; }
-      .Radio--large-md .Radio__indicator::after {
-        height: 7px;
-        left: 5px;
-        top: 5px;
-        width: 7px; } }
+  .Radio--large-md .Radio__indicator {
+    height: 21px;
+    top: 2px;
+    width: 21px; }
+  .Radio--large-md .Radio__indicator::after {
+    height: 7px;
+    left: 5px;
+    top: 5px;
+    width: 7px; } }
 
 @media (min-width: 1200px) {
   .Radio--small-lg {
@@ -1014,45 +1058,45 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-    .Radio--small-lg .Radio__indicator {
-      height: 14px;
-      top: 1px;
-      width: 14px; }
-      .Radio--small-lg .Radio__indicator::after {
-        height: 6px;
-        left: 2px;
-        top: 2px;
-        width: 6px; }
+  .Radio--small-lg .Radio__indicator {
+    height: 14px;
+    top: 1px;
+    width: 14px; }
+  .Radio--small-lg .Radio__indicator::after {
+    height: 6px;
+    left: 2px;
+    top: 2px;
+    width: 6px; }
   .Radio--medium-lg {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Radio--medium-lg .Radio__indicator {
-      height: 16px;
-      top: 1px;
-      width: 16px; }
-      .Radio--medium-lg .Radio__indicator::after {
-        height: 6px;
-        left: 3px;
-        top: 3px;
-        width: 6px; }
+  .Radio--medium-lg .Radio__indicator {
+    height: 16px;
+    top: 1px;
+    width: 16px; }
+  .Radio--medium-lg .Radio__indicator::after {
+    height: 6px;
+    left: 3px;
+    top: 3px;
+    width: 6px; }
   .Radio--large-lg {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-    .Radio--large-lg .Radio__indicator {
-      height: 21px;
-      top: 2px;
-      width: 21px; }
-      .Radio--large-lg .Radio__indicator::after {
-        height: 7px;
-        left: 5px;
-        top: 5px;
-        width: 7px; } }
+  .Radio--large-lg .Radio__indicator {
+    height: 21px;
+    top: 2px;
+    width: 21px; }
+  .Radio--large-lg .Radio__indicator::after {
+    height: 7px;
+    left: 5px;
+    top: 5px;
+    width: 7px; } }
 
 @media (min-width: 1500px) {
   .Radio--small-xl {
@@ -1061,60 +1105,63 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-    .Radio--small-xl .Radio__indicator {
-      height: 14px;
-      top: 1px;
-      width: 14px; }
-      .Radio--small-xl .Radio__indicator::after {
-        height: 6px;
-        left: 2px;
-        top: 2px;
-        width: 6px; }
+  .Radio--small-xl .Radio__indicator {
+    height: 14px;
+    top: 1px;
+    width: 14px; }
+  .Radio--small-xl .Radio__indicator::after {
+    height: 6px;
+    left: 2px;
+    top: 2px;
+    width: 6px; }
   .Radio--medium-xl {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-    .Radio--medium-xl .Radio__indicator {
-      height: 16px;
-      top: 1px;
-      width: 16px; }
-      .Radio--medium-xl .Radio__indicator::after {
-        height: 6px;
-        left: 3px;
-        top: 3px;
-        width: 6px; }
+  .Radio--medium-xl .Radio__indicator {
+    height: 16px;
+    top: 1px;
+    width: 16px; }
+  .Radio--medium-xl .Radio__indicator::after {
+    height: 6px;
+    left: 3px;
+    top: 3px;
+    width: 6px; }
   .Radio--large-xl {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-    .Radio--large-xl .Radio__indicator {
-      height: 21px;
-      top: 2px;
-      width: 21px; }
-      .Radio--large-xl .Radio__indicator::after {
-        height: 7px;
-        left: 5px;
-        top: 5px;
-        width: 7px; } }
+  .Radio--large-xl .Radio__indicator {
+    height: 21px;
+    top: 2px;
+    width: 21px; }
+  .Radio--large-xl .Radio__indicator::after {
+    height: 7px;
+    left: 5px;
+    top: 5px;
+    width: 7px; } }
 
 .Switch {
   margin: 0;
   position: relative; }
-  .Switch .Switch__indicator {
-    border-radius: 12px;
-    height: 24px;
-    width: 41px; }
-  .Switch .Switch__toggler {
-    height: 20px;
-    right: 19px;
-    width: 20px; }
-    .Switch .Switch__toggler::after {
-      height: 8px;
-      width: 8px; }
+
+.Switch .Switch__indicator {
+  border-radius: 12px;
+  height: 24px;
+  width: 41px; }
+
+.Switch .Switch__toggler {
+  height: 20px;
+  right: 19px;
+  width: 20px; }
+
+.Switch .Switch__toggler::after {
+  height: 8px;
+  width: 8px; }
 
 .Switch__indicator {
   background-color: #dbdbdb;
@@ -1128,37 +1175,42 @@ hr {
   position: absolute;
   top: 2px;
   transition: right .15s ease-out; }
-  .Switch__toggler::after {
-    background-color: #7feaff;
-    border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
-    content: ' ';
-    left: 50%;
-    opacity: 0;
-    position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%);
-    transition: opacity .15s linear; }
+
+.Switch__toggler::after {
+  background-color: #7feaff;
+  border-radius: 50%;
+  box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
+  content: ' ';
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: opacity .15s linear; }
 
 .Switch__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-  .Switch__input:checked ~ .Switch__indicator {
-    background-color: #2dcfa1; }
-    .Switch__input:checked ~ .Switch__indicator .Switch__toggler {
-      right: 2px; }
-  .Switch__input:disabled ~ .Switch__indicator {
-    cursor: not-allowed;
-    opacity: 0.54; }
+
+.Switch__input:checked ~ .Switch__indicator {
+  background-color: #2dcfa1; }
+
+.Switch__input:checked ~ .Switch__indicator .Switch__toggler {
+  right: 2px; }
+
+.Switch__input:disabled ~ .Switch__indicator {
+  cursor: not-allowed;
+  opacity: 0.54; }
 
 .Switch--is-focused .Switch__toggler::after {
   opacity: 1; }
 
 .Tab {
   display: inline-block; }
-  .Tab:not(:last-child) {
-    margin-right: 0.875em; }
+
+.Tab:not(:last-child) {
+  margin-right: 0.875em; }
 
 .Tab--is-active {
   border-bottom: 2px solid #000; }
@@ -1172,9 +1224,10 @@ hr {
   color: rgba(0, 0, 0, 0.86);
   line-height: 1.49271;
   width: 100%; }
-  .TextInput::placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
+
+.TextInput::placeholder {
+  color: rgba(0, 0, 0, 0.41);
+  opacity: 1; }
 
 .TextInput:focus {
   border-color: #7feaff;
@@ -1192,9 +1245,10 @@ hr {
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
   border-color: #f04d5d; }
-  .TextInput--has-error.TextInput:focus,
-  .FormGroup--has-error .TextInput.TextInput:focus {
-    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+
+.TextInput--has-error.TextInput:focus,
+.FormGroup--has-error .TextInput.TextInput:focus {
+  box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {
@@ -1281,9 +1335,10 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-  .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+
+.FormGroup__error::before {
+  content: '✘ ';
+  display: inline; }
 
 .FormGroup__hint {
   font-size: 12px;
@@ -1320,9 +1375,10 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-  .FormGroup--medium .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+
+.FormGroup--medium .FormGroup__error::before {
+  content: '✘ ';
+  display: inline; }
 
 .FormGroup--medium .FormGroup__hint {
   font-size: 12px;
@@ -1375,9 +1431,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-sm .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-sm .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-sm .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1426,9 +1482,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-md .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-md .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-md .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1477,9 +1533,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-lg .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-lg .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-lg .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1528,9 +1584,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-    .FormGroup--medium-xl .FormGroup__error::before {
-      content: '✘ ';
-      display: inline; }
+  .FormGroup--medium-xl .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
   .FormGroup--medium-xl .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -2039,90 +2095,107 @@ hr {
   padding-left: 12px;
   width: 451px;
   max-width: 100%; }
-  @media (min-width: 600px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .container {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 600px) {
-    .container {
-      width: 673px;
-      max-width: 100%; } }
-  @media (min-width: 900px) {
-    .container {
-      width: 879px;
-      max-width: 100%; } }
-  @media (min-width: 1200px) {
-    .container {
-      width: 1148px;
-      max-width: 100%; } }
-  @media (min-width: 1500px) {
-    .container {
-      width: 1148px;
-      max-width: 100%; } }
+
+@media (min-width: 600px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container {
+    width: 673px;
+    max-width: 100%; } }
+
+@media (min-width: 900px) {
+  .container {
+    width: 879px;
+    max-width: 100%; } }
+
+@media (min-width: 1200px) {
+  .container {
+    width: 1148px;
+    max-width: 100%; } }
+
+@media (min-width: 1500px) {
+  .container {
+    width: 1148px;
+    max-width: 100%; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .container-fluid {
-      padding-right: 12px;
-      padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .container-fluid {
+    padding-right: 12px;
+    padding-left: 12px; } }
 
 .row {
   display: flex;
   flex-wrap: wrap;
   margin-right: -12px;
   margin-left: -12px; }
-  @media (min-width: 600px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 900px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 1200px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
-  @media (min-width: 1500px) {
-    .row {
-      margin-right: -12px;
-      margin-left: -12px; } }
+
+@media (min-width: 600px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 900px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1200px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
+
+@media (min-width: 1500px) {
+  .row {
+    margin-right: -12px;
+    margin-left: -12px; } }
 
 .no-gutters {
   margin-right: 0;
   margin-left: 0; }
-  .no-gutters > .col,
-  .no-gutters > [class*="col-"] {
-    padding-right: 0;
-    padding-left: 0; }
+
+.no-gutters > .col,
+.no-gutters > [class*="col-"] {
+  padding-right: 0;
+  padding-left: 0; }
 
 .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
   position: relative;
@@ -2130,22 +2203,26 @@ hr {
   min-height: 1px;
   padding-right: 12px;
   padding-left: 12px; }
-  @media (min-width: 600px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 900px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1200px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
-  @media (min-width: 1500px) {
-    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-      padding-right: 12px;
-      padding-left: 12px; } }
+
+@media (min-width: 600px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 900px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1200px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
+
+@media (min-width: 1500px) {
+  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+    padding-right: 12px;
+    padding-left: 12px; } }
 
 .col {
   flex-basis: 0;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -167,21 +167,18 @@ a {
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
-
-a:hover {
-  color: #008ab3;
-  text-decoration: underline; }
+  a:hover {
+    color: #008ab3;
+    text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
   color: inherit;
   text-decoration: none; }
-
-a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
-  color: inherit;
-  text-decoration: none; }
-
-a:not([href]):not([tabindex]):focus {
-  outline: 0; }
+  a:not([href]):not([tabindex]):focus, a:not([href]):not([tabindex]):hover {
+    color: inherit;
+    text-decoration: none; }
+  a:not([href]):not([tabindex]):focus {
+    outline: 0; }
 
 pre,
 code,
@@ -377,8 +374,12 @@ hr {
   border-color: rgba(255, 255, 255, 0.14); }
 
 .Button {
-  font-size: 16px;
-  padding: 11px 21px 12px;
+  display: inline-block; }
+  .Button .Button__control {
+    font-size: 16px;
+    padding: 11px 21px 12px; }
+
+.Button__control {
   background: rgba(0, 0, 0, 0.07);
   border: 0;
   border-radius: 3px;
@@ -396,8 +397,8 @@ hr {
   -webkit-user-select: none;
   user-select: none; }
 
-.Button:hover,
-.Button:focus {
+.Button__control:hover,
+.Button__control:focus {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   background: rgba(0, 0, 0, 0.12);
   color: rgba(0, 0, 0, 0.86);
@@ -405,129 +406,123 @@ hr {
   transform: translateY(-2.25px) scaleX(1.015) scaleY(1.015);
   transition-duration: .08s; }
 
-.Button:disabled,
 .Button--is-disabled {
-  opacity: 0.54;
-  pointer-events: none; }
+  cursor: not-allowed; }
+  .Button--is-disabled .Button__control {
+    opacity: 0.54;
+    pointer-events: none; }
 
-.Button:active,
-.Button--is-active,
-.Button--is-active:focus {
+.Button__control:active,
+.Button--is-active .Button__control,
+.Button--is-active .Button__control:focus {
   box-shadow: none;
   background: rgba(0, 0, 0, 0.18);
   transform: translateY(0) scaleX(1) scaleY(1);
   transition-duration: 0s; }
 
-.Button:active:focus {
+.Button__control:active:focus {
   outline: 0; }
 
-.Button--danger {
+.Button--danger .Button__control {
   color: #fff;
   font-weight: normal;
   background: #f04d5d; }
+  .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
+    background: #ee3548;
+    color: #fff; }
+  .Button--danger .Button__control:active {
+    background: #ec192e; }
 
-.Button--danger:hover, .Button--danger:focus {
-  background: #ee3548;
-  color: #fff; }
-
-.Button--danger:active, .Button--danger.Button--is-active {
-  background: #ec192e; }
-
-.Button--primary {
+.Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   color: #fff;
   font-weight: bold;
   -webkit-font-smoothing: antialiased;
   background: #16b8e0; }
+  .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
+    background: #14a5c9;
+    color: #fff; }
+  .Button--primary .Button__control:active {
+    box-shadow: none;
+    background: #118ead; }
 
-.Button--primary:hover, .Button--primary:focus {
-  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
-  background: #14a5c9;
-  color: #fff; }
-
-.Button--primary:active, .Button--primary.Button--is-active {
-  box-shadow: none;
-  background: #118ead; }
-
-.Button--link {
+.Button--link .Button__control {
   background: transparent;
   color: #16b8e0; }
-
-.Button--link:hover, .Button--link:focus {
-  background: rgba(0, 0, 0, 0.05);
-  color: #008ab3; }
-
-.Button--link:active, .Button--link.Button--is-active {
-  background: rgba(0, 0, 0, 0.11);
-  color: #005678; }
+  .Button--link .Button__control:hover, .Button--link .Button__control:focus {
+    background: rgba(0, 0, 0, 0.05);
+    color: #008ab3; }
+  .Button--link .Button__control:active {
+    background: rgba(0, 0, 0, 0.11);
+    color: #005678; }
 
 @media (pointer: coarse), (any-pointer: coarse) {
-  .Button:hover {
+  .Button__control:hover {
     box-shadow: none;
     background: rgba(0, 0, 0, 0.18);
     transform: translateY(1px) scaleX(0.985) scaleY(0.985); }
-  .Button--danger:hover {
+  .Button--danger .Button__control:hover {
     background: #ec192e; }
-  .Button--primary:hover {
-    box-shadow: none;
+  .Button--primary .Button__control:hover {
     background: #118ead; }
-  .Button--link:hover {
+  .Button--link .Button__control:hover {
     background: rgba(0, 0, 0, 0.11);
     color: #005678; } }
 
-.Button--medium {
+.Button--medium .Button__control {
   font-size: 16px;
   padding: 11px 21px 12px; }
 
-.Button--small {
+.Button--small .Button__control {
   font-size: 14px;
   padding: 7px 14px 8px; }
 
-.Button--large {
+.Button--large .Button__control {
   font-size: 18px;
   padding: 16px 27px 18px; }
 
 @media (min-width: 600px) {
-  .Button--medium-sm {
+  .Button--medium-sm .Button__control {
     font-size: 16px;
     padding: 11px 21px 12px; }
-  .Button--small-sm {
+  .Button--small-sm .Button__control {
     font-size: 14px;
     padding: 7px 14px 8px; }
-  .Button--large-sm {
+  .Button--large-sm .Button__control {
     font-size: 18px;
     padding: 16px 27px 18px; } }
 
 @media (min-width: 900px) {
-  .Button--medium-md {
+  .Button--medium-md .Button__control {
     font-size: 16px;
     padding: 11px 21px 12px; }
-  .Button--small-md {
+  .Button--small-md .Button__control {
     font-size: 14px;
     padding: 7px 14px 8px; }
-  .Button--large-md {
+  .Button--large-md .Button__control {
     font-size: 18px;
     padding: 16px 27px 18px; } }
 
 @media (min-width: 1200px) {
-  .Button--medium-lg {
+  .Button--medium-lg .Button__control {
     font-size: 16px;
     padding: 11px 21px 12px; }
-  .Button--small-lg {
+  .Button--small-lg .Button__control {
     font-size: 14px;
     padding: 7px 14px 8px; }
-  .Button--large-lg {
+  .Button--large-lg .Button__control {
     font-size: 18px;
     padding: 16px 27px 18px; } }
 
 @media (min-width: 1500px) {
-  .Button--medium-xl {
+  .Button--medium-xl .Button__control {
     font-size: 16px;
     padding: 11px 21px 12px; }
-  .Button--small-xl {
+  .Button--small-xl .Button__control {
     font-size: 14px;
     padding: 7px 14px 8px; }
-  .Button--large-xl {
+  .Button--large-xl .Button__control {
     font-size: 18px;
     padding: 16px 27px 18px; } }
 
@@ -540,52 +535,43 @@ hr {
   display: inline-block;
   margin: 0;
   position: relative; }
-
-.Checkbox .Checkbox__indicator {
-  background-position: 1px 2px;
-  background-size: 10px 9px;
-  height: 16px;
-  top: 1px;
-  width: 16px; }
+  .Checkbox .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
 
 .Checkbox__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-
-.Checkbox__input:focus ~ .Checkbox__indicator {
-  border-color: #7feaff;
-  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
-
-.Checkbox__input:active ~ .Checkbox__indicator {
-  background-color: #f9f9f9;
-  border-color: #c1c1c1; }
-
-.Checkbox__input:checked ~ .Checkbox__indicator {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-  background-color: #232323;
-  border-color: #232323; }
-
-.Checkbox__input:checked:focus ~ .Checkbox__indicator {
-  border-color: #232323;
-  box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
-
-.Checkbox__input:checked:active ~ .Checkbox__indicator {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
-  background-color: #232323;
-  border-color: #232323; }
-
-.Checkbox__input:disabled ~ .Checkbox__indicator,
-.Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
-  background-color: #eee;
-  border-color: #eee; }
-
-.Checkbox__input:disabled:checked ~ .Checkbox__indicator,
-.Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
-  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
-
-.Checkbox__input:disabled ~ .Checkbox__label {
-  color: rgba(0, 0, 0, 0.54); }
+  .Checkbox__input:focus ~ .Checkbox__indicator {
+    border-color: #7feaff;
+    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+  .Checkbox__input:active ~ .Checkbox__indicator {
+    background-color: #f9f9f9;
+    border-color: #c1c1c1; }
+  .Checkbox__input:checked ~ .Checkbox__indicator {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+    background-color: #232323;
+    border-color: #232323; }
+  .Checkbox__input:checked:focus ~ .Checkbox__indicator {
+    border-color: #232323;
+    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+  .Checkbox__input:checked:active ~ .Checkbox__indicator {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
+    background-color: #232323;
+    border-color: #232323; }
+  .Checkbox__input:disabled ~ .Checkbox__indicator,
+  .Checkbox__input:disabled:active ~ .Checkbox__indicator, .Checkbox__input:disabled:checked:active {
+    background-color: #eee;
+    border-color: #eee; }
+  .Checkbox__input:disabled:checked ~ .Checkbox__indicator,
+  .Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
+    background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
+  .Checkbox__input:disabled ~ .Checkbox__label {
+    color: rgba(0, 0, 0, 0.54); }
 
 .Checkbox__indicator {
   background-color: #fff;
@@ -603,13 +589,12 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 23px; }
-
-.Checkbox--medium .Checkbox__indicator {
-  background-position: 1px 2px;
-  background-size: 10px 9px;
-  height: 16px;
-  top: 1px;
-  width: 16px; }
+  .Checkbox--medium .Checkbox__indicator {
+    background-position: 1px 2px;
+    background-size: 10px 9px;
+    height: 16px;
+    top: 1px;
+    width: 16px; }
 
 .Checkbox--small {
   font-size: 12px;
@@ -617,13 +602,12 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 21px; }
-
-.Checkbox--small .Checkbox__indicator {
-  background-position: 1px 1px;
-  background-size: 8px 8px;
-  height: 14px;
-  top: 1px;
-  width: 14px; }
+  .Checkbox--small .Checkbox__indicator {
+    background-position: 1px 1px;
+    background-size: 8px 8px;
+    height: 14px;
+    top: 1px;
+    width: 14px; }
 
 .Checkbox--large {
   font-size: 18px;
@@ -631,13 +615,12 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 32px; }
-
-.Checkbox--large .Checkbox__indicator {
-  background-position: 2px 3px;
-  background-size: 14px 11px;
-  height: 21px;
-  top: 2px;
-  width: 21px; }
+  .Checkbox--large .Checkbox__indicator {
+    background-position: 2px 3px;
+    background-size: 14px 11px;
+    height: 21px;
+    top: 2px;
+    width: 21px; }
 
 @media (min-width: 600px) {
   .Checkbox--medium-sm {
@@ -646,36 +629,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-sm .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-sm .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-sm {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-sm .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-sm .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-sm {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-sm .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-sm .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 @media (min-width: 900px) {
   .Checkbox--medium-md {
@@ -684,36 +667,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-md .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-md .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-md {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-md .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-md .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-md {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-md .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-md .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 @media (min-width: 1200px) {
   .Checkbox--medium-lg {
@@ -722,36 +705,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-lg .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-lg .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-lg {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-lg .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-lg .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-lg {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-lg .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-lg .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 @media (min-width: 1500px) {
   .Checkbox--medium-xl {
@@ -760,36 +743,36 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 23px; }
-  .Checkbox--medium-xl .Checkbox__indicator {
-    background-position: 1px 2px;
-    background-size: 10px 9px;
-    height: 16px;
-    top: 1px;
-    width: 16px; }
+    .Checkbox--medium-xl .Checkbox__indicator {
+      background-position: 1px 2px;
+      background-size: 10px 9px;
+      height: 16px;
+      top: 1px;
+      width: 16px; }
   .Checkbox--small-xl {
     font-size: 12px;
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Checkbox--small-xl .Checkbox__indicator {
-    background-position: 1px 1px;
-    background-size: 8px 8px;
-    height: 14px;
-    top: 1px;
-    width: 14px; }
+    .Checkbox--small-xl .Checkbox__indicator {
+      background-position: 1px 1px;
+      background-size: 8px 8px;
+      height: 14px;
+      top: 1px;
+      width: 14px; }
   .Checkbox--large-xl {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 32px; }
-  .Checkbox--large-xl .Checkbox__indicator {
-    background-position: 2px 3px;
-    background-size: 14px 11px;
-    height: 21px;
-    top: 2px;
-    width: 21px; } }
+    .Checkbox--large-xl .Checkbox__indicator {
+      background-position: 2px 3px;
+      background-size: 14px 11px;
+      height: 21px;
+      top: 2px;
+      width: 21px; } }
 
 .Message {
   background-color: #eee;
@@ -817,61 +800,49 @@ hr {
   display: inline-block;
   margin: 0;
   position: relative; }
-
-.Radio .Radio__indicator {
-  height: 16px;
-  top: 1px;
-  width: 16px; }
-
-.Radio .Radio__indicator::after {
-  height: 6px;
-  left: 3px;
-  top: 3px;
-  width: 6px; }
+  .Radio .Radio__indicator {
+    height: 16px;
+    top: 1px;
+    width: 16px; }
+    .Radio .Radio__indicator::after {
+      height: 6px;
+      left: 3px;
+      top: 3px;
+      width: 6px; }
 
 .Radio__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-
-.Radio__input:focus ~ .Radio__indicator {
-  border-color: #7feaff;
-  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
-
-.Radio__input:active ~ .Radio__indicator {
-  background-color: #f9f9f9;
-  border-color: #c1c1c1; }
-
-.Radio__input:checked ~ .Radio__indicator {
-  background-color: #232323;
-  border-color: #232323;
-  color: #fff; }
-
-.Radio__input:checked ~ .Radio__indicator::after {
-  display: block; }
-
-.Radio__input:checked:focus ~ .Radio__indicator {
-  border-color: #232323;
-  box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
-
-.Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
-  background-color: #232323;
-  border-color: #232323; }
-
-.Radio__input:checked:active:not(:disabled) ~ .Radio__indicator::after {
-  opacity: 0.54; }
-
-.Radio__input:disabled ~ .Radio__indicator,
-.Radio__input:disabled:active ~ .Radio__indicator, .Radio__input:disabled:checked:active {
-  background-color: #eee;
-  border-color: #eee; }
-
-.Radio__input:disabled:checked ~ .Radio__indicator::after,
-.Radio__input:disabled:checked:active ~ .Radio__indicator::after {
-  background-color: #c1c1c1; }
-
-.Radio__input:disabled ~ .Radio__label {
-  color: rgba(0, 0, 0, 0.54); }
+  .Radio__input:focus ~ .Radio__indicator {
+    border-color: #7feaff;
+    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+  .Radio__input:active ~ .Radio__indicator {
+    background-color: #f9f9f9;
+    border-color: #c1c1c1; }
+  .Radio__input:checked ~ .Radio__indicator {
+    background-color: #232323;
+    border-color: #232323;
+    color: #fff; }
+    .Radio__input:checked ~ .Radio__indicator::after {
+      display: block; }
+  .Radio__input:checked:focus ~ .Radio__indicator {
+    border-color: #232323;
+    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+  .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
+    background-color: #232323;
+    border-color: #232323; }
+    .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator::after {
+      opacity: 0.54; }
+  .Radio__input:disabled ~ .Radio__indicator,
+  .Radio__input:disabled:active ~ .Radio__indicator, .Radio__input:disabled:checked:active {
+    background-color: #eee;
+    border-color: #eee; }
+  .Radio__input:disabled:checked ~ .Radio__indicator::after,
+  .Radio__input:disabled:checked:active ~ .Radio__indicator::after {
+    background-color: #c1c1c1; }
+  .Radio__input:disabled ~ .Radio__label {
+    color: rgba(0, 0, 0, 0.54); }
 
 .Radio__indicator {
   background-color: #fff;
@@ -881,13 +852,12 @@ hr {
   pointer-events: none;
   position: absolute;
   user-select: none; }
-
-.Radio__indicator::after {
-  background-color: #fff;
-  border-radius: 50%;
-  content: '';
-  display: none;
-  position: absolute; }
+  .Radio__indicator::after {
+    background-color: #fff;
+    border-radius: 50%;
+    content: '';
+    display: none;
+    position: absolute; }
 
 .Radio--small {
   font-size: 12px;
@@ -895,17 +865,15 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 19px; }
-
-.Radio--small .Radio__indicator {
-  height: 14px;
-  top: 1px;
-  width: 14px; }
-
-.Radio--small .Radio__indicator::after {
-  height: 6px;
-  left: 2px;
-  top: 2px;
-  width: 6px; }
+  .Radio--small .Radio__indicator {
+    height: 14px;
+    top: 1px;
+    width: 14px; }
+    .Radio--small .Radio__indicator::after {
+      height: 6px;
+      left: 2px;
+      top: 2px;
+      width: 6px; }
 
 .Radio--medium {
   font-size: 14px;
@@ -913,17 +881,15 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 21px; }
-
-.Radio--medium .Radio__indicator {
-  height: 16px;
-  top: 1px;
-  width: 16px; }
-
-.Radio--medium .Radio__indicator::after {
-  height: 6px;
-  left: 3px;
-  top: 3px;
-  width: 6px; }
+  .Radio--medium .Radio__indicator {
+    height: 16px;
+    top: 1px;
+    width: 16px; }
+    .Radio--medium .Radio__indicator::after {
+      height: 6px;
+      left: 3px;
+      top: 3px;
+      width: 6px; }
 
 .Radio--large {
   font-size: 18px;
@@ -931,17 +897,15 @@ hr {
   letter-spacing: 0px;
   font-weight: normal;
   padding-left: 28px; }
-
-.Radio--large .Radio__indicator {
-  height: 21px;
-  top: 2px;
-  width: 21px; }
-
-.Radio--large .Radio__indicator::after {
-  height: 7px;
-  left: 5px;
-  top: 5px;
-  width: 7px; }
+  .Radio--large .Radio__indicator {
+    height: 21px;
+    top: 2px;
+    width: 21px; }
+    .Radio--large .Radio__indicator::after {
+      height: 7px;
+      left: 5px;
+      top: 5px;
+      width: 7px; }
 
 @media (min-width: 600px) {
   .Radio--small-sm {
@@ -950,45 +914,45 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-  .Radio--small-sm .Radio__indicator {
-    height: 14px;
-    top: 1px;
-    width: 14px; }
-  .Radio--small-sm .Radio__indicator::after {
-    height: 6px;
-    left: 2px;
-    top: 2px;
-    width: 6px; }
+    .Radio--small-sm .Radio__indicator {
+      height: 14px;
+      top: 1px;
+      width: 14px; }
+      .Radio--small-sm .Radio__indicator::after {
+        height: 6px;
+        left: 2px;
+        top: 2px;
+        width: 6px; }
   .Radio--medium-sm {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Radio--medium-sm .Radio__indicator {
-    height: 16px;
-    top: 1px;
-    width: 16px; }
-  .Radio--medium-sm .Radio__indicator::after {
-    height: 6px;
-    left: 3px;
-    top: 3px;
-    width: 6px; }
+    .Radio--medium-sm .Radio__indicator {
+      height: 16px;
+      top: 1px;
+      width: 16px; }
+      .Radio--medium-sm .Radio__indicator::after {
+        height: 6px;
+        left: 3px;
+        top: 3px;
+        width: 6px; }
   .Radio--large-sm {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-  .Radio--large-sm .Radio__indicator {
-    height: 21px;
-    top: 2px;
-    width: 21px; }
-  .Radio--large-sm .Radio__indicator::after {
-    height: 7px;
-    left: 5px;
-    top: 5px;
-    width: 7px; } }
+    .Radio--large-sm .Radio__indicator {
+      height: 21px;
+      top: 2px;
+      width: 21px; }
+      .Radio--large-sm .Radio__indicator::after {
+        height: 7px;
+        left: 5px;
+        top: 5px;
+        width: 7px; } }
 
 @media (min-width: 900px) {
   .Radio--small-md {
@@ -997,45 +961,45 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-  .Radio--small-md .Radio__indicator {
-    height: 14px;
-    top: 1px;
-    width: 14px; }
-  .Radio--small-md .Radio__indicator::after {
-    height: 6px;
-    left: 2px;
-    top: 2px;
-    width: 6px; }
+    .Radio--small-md .Radio__indicator {
+      height: 14px;
+      top: 1px;
+      width: 14px; }
+      .Radio--small-md .Radio__indicator::after {
+        height: 6px;
+        left: 2px;
+        top: 2px;
+        width: 6px; }
   .Radio--medium-md {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Radio--medium-md .Radio__indicator {
-    height: 16px;
-    top: 1px;
-    width: 16px; }
-  .Radio--medium-md .Radio__indicator::after {
-    height: 6px;
-    left: 3px;
-    top: 3px;
-    width: 6px; }
+    .Radio--medium-md .Radio__indicator {
+      height: 16px;
+      top: 1px;
+      width: 16px; }
+      .Radio--medium-md .Radio__indicator::after {
+        height: 6px;
+        left: 3px;
+        top: 3px;
+        width: 6px; }
   .Radio--large-md {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-  .Radio--large-md .Radio__indicator {
-    height: 21px;
-    top: 2px;
-    width: 21px; }
-  .Radio--large-md .Radio__indicator::after {
-    height: 7px;
-    left: 5px;
-    top: 5px;
-    width: 7px; } }
+    .Radio--large-md .Radio__indicator {
+      height: 21px;
+      top: 2px;
+      width: 21px; }
+      .Radio--large-md .Radio__indicator::after {
+        height: 7px;
+        left: 5px;
+        top: 5px;
+        width: 7px; } }
 
 @media (min-width: 1200px) {
   .Radio--small-lg {
@@ -1044,45 +1008,45 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-  .Radio--small-lg .Radio__indicator {
-    height: 14px;
-    top: 1px;
-    width: 14px; }
-  .Radio--small-lg .Radio__indicator::after {
-    height: 6px;
-    left: 2px;
-    top: 2px;
-    width: 6px; }
+    .Radio--small-lg .Radio__indicator {
+      height: 14px;
+      top: 1px;
+      width: 14px; }
+      .Radio--small-lg .Radio__indicator::after {
+        height: 6px;
+        left: 2px;
+        top: 2px;
+        width: 6px; }
   .Radio--medium-lg {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Radio--medium-lg .Radio__indicator {
-    height: 16px;
-    top: 1px;
-    width: 16px; }
-  .Radio--medium-lg .Radio__indicator::after {
-    height: 6px;
-    left: 3px;
-    top: 3px;
-    width: 6px; }
+    .Radio--medium-lg .Radio__indicator {
+      height: 16px;
+      top: 1px;
+      width: 16px; }
+      .Radio--medium-lg .Radio__indicator::after {
+        height: 6px;
+        left: 3px;
+        top: 3px;
+        width: 6px; }
   .Radio--large-lg {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-  .Radio--large-lg .Radio__indicator {
-    height: 21px;
-    top: 2px;
-    width: 21px; }
-  .Radio--large-lg .Radio__indicator::after {
-    height: 7px;
-    left: 5px;
-    top: 5px;
-    width: 7px; } }
+    .Radio--large-lg .Radio__indicator {
+      height: 21px;
+      top: 2px;
+      width: 21px; }
+      .Radio--large-lg .Radio__indicator::after {
+        height: 7px;
+        left: 5px;
+        top: 5px;
+        width: 7px; } }
 
 @media (min-width: 1500px) {
   .Radio--small-xl {
@@ -1091,63 +1055,60 @@ hr {
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 19px; }
-  .Radio--small-xl .Radio__indicator {
-    height: 14px;
-    top: 1px;
-    width: 14px; }
-  .Radio--small-xl .Radio__indicator::after {
-    height: 6px;
-    left: 2px;
-    top: 2px;
-    width: 6px; }
+    .Radio--small-xl .Radio__indicator {
+      height: 14px;
+      top: 1px;
+      width: 14px; }
+      .Radio--small-xl .Radio__indicator::after {
+        height: 6px;
+        left: 2px;
+        top: 2px;
+        width: 6px; }
   .Radio--medium-xl {
     font-size: 14px;
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 21px; }
-  .Radio--medium-xl .Radio__indicator {
-    height: 16px;
-    top: 1px;
-    width: 16px; }
-  .Radio--medium-xl .Radio__indicator::after {
-    height: 6px;
-    left: 3px;
-    top: 3px;
-    width: 6px; }
+    .Radio--medium-xl .Radio__indicator {
+      height: 16px;
+      top: 1px;
+      width: 16px; }
+      .Radio--medium-xl .Radio__indicator::after {
+        height: 6px;
+        left: 3px;
+        top: 3px;
+        width: 6px; }
   .Radio--large-xl {
     font-size: 18px;
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
     padding-left: 28px; }
-  .Radio--large-xl .Radio__indicator {
-    height: 21px;
-    top: 2px;
-    width: 21px; }
-  .Radio--large-xl .Radio__indicator::after {
-    height: 7px;
-    left: 5px;
-    top: 5px;
-    width: 7px; } }
+    .Radio--large-xl .Radio__indicator {
+      height: 21px;
+      top: 2px;
+      width: 21px; }
+      .Radio--large-xl .Radio__indicator::after {
+        height: 7px;
+        left: 5px;
+        top: 5px;
+        width: 7px; } }
 
 .Switch {
   margin: 0;
   position: relative; }
-
-.Switch .Switch__indicator {
-  border-radius: 12px;
-  height: 24px;
-  width: 41px; }
-
-.Switch .Switch__toggler {
-  height: 20px;
-  right: 19px;
-  width: 20px; }
-
-.Switch .Switch__toggler::after {
-  height: 8px;
-  width: 8px; }
+  .Switch .Switch__indicator {
+    border-radius: 12px;
+    height: 24px;
+    width: 41px; }
+  .Switch .Switch__toggler {
+    height: 20px;
+    right: 19px;
+    width: 20px; }
+    .Switch .Switch__toggler::after {
+      height: 8px;
+      width: 8px; }
 
 .Switch__indicator {
   background-color: #dbdbdb;
@@ -1161,42 +1122,37 @@ hr {
   position: absolute;
   top: 2px;
   transition: right .15s ease-out; }
-
-.Switch__toggler::after {
-  background-color: #7feaff;
-  border-radius: 50%;
-  box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
-  content: ' ';
-  left: 50%;
-  opacity: 0;
-  position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  transition: opacity .15s linear; }
+  .Switch__toggler::after {
+    background-color: #7feaff;
+    border-radius: 50%;
+    box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
+    content: ' ';
+    left: 50%;
+    opacity: 0;
+    position: absolute;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    transition: opacity .15s linear; }
 
 .Switch__input {
   opacity: 0;
   position: absolute;
   z-index: -1; }
-
-.Switch__input:checked ~ .Switch__indicator {
-  background-color: #2dcfa1; }
-
-.Switch__input:checked ~ .Switch__indicator .Switch__toggler {
-  right: 2px; }
-
-.Switch__input:disabled ~ .Switch__indicator {
-  cursor: not-allowed;
-  opacity: 0.54; }
+  .Switch__input:checked ~ .Switch__indicator {
+    background-color: #2dcfa1; }
+    .Switch__input:checked ~ .Switch__indicator .Switch__toggler {
+      right: 2px; }
+  .Switch__input:disabled ~ .Switch__indicator {
+    cursor: not-allowed;
+    opacity: 0.54; }
 
 .Switch--is-focused .Switch__toggler::after {
   opacity: 1; }
 
 .Tab {
   display: inline-block; }
-
-.Tab:not(:last-child) {
-  margin-right: 0.875em; }
+  .Tab:not(:last-child) {
+    margin-right: 0.875em; }
 
 .Tab--is-active {
   border-bottom: 2px solid #000; }
@@ -1210,10 +1166,9 @@ hr {
   color: rgba(0, 0, 0, 0.86);
   line-height: 1.49271;
   width: 100%; }
-
-.TextInput::placeholder {
-  color: rgba(0, 0, 0, 0.41);
-  opacity: 1; }
+  .TextInput::placeholder {
+    color: rgba(0, 0, 0, 0.41);
+    opacity: 1; }
 
 .TextInput:focus,
 .TextInput--is-focused {
@@ -1232,11 +1187,10 @@ hr {
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
   border-color: #f04d5d; }
-
-.TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
-.FormGroup--has-error .TextInput.TextInput:focus,
-.FormGroup--has-error .TextInput.TextInput--is-focused {
-  box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+  .TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
+  .FormGroup--has-error .TextInput.TextInput:focus,
+  .FormGroup--has-error .TextInput.TextInput--is-focused {
+    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {
@@ -1323,10 +1277,9 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-
-.FormGroup__error::before {
-  content: '✘ ';
-  display: inline; }
+  .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
 
 .FormGroup__hint {
   font-size: 12px;
@@ -1363,10 +1316,9 @@ hr {
   font-weight: normal;
   color: #f04d5d;
   margin-top: 7px; }
-
-.FormGroup--medium .FormGroup__error::before {
-  content: '✘ ';
-  display: inline; }
+  .FormGroup--medium .FormGroup__error::before {
+    content: '✘ ';
+    display: inline; }
 
 .FormGroup--medium .FormGroup__hint {
   font-size: 12px;
@@ -1419,9 +1371,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-sm .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-sm .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-sm .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1470,9 +1422,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-md .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-md .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-md .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1521,9 +1473,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-lg .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-lg .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-lg .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -1572,9 +1524,9 @@ hr {
     font-weight: normal;
     color: #f04d5d;
     margin-top: 7px; }
-  .FormGroup--medium-xl .FormGroup__error::before {
-    content: '✘ ';
-    display: inline; }
+    .FormGroup--medium-xl .FormGroup__error::before {
+      content: '✘ ';
+      display: inline; }
   .FormGroup--medium-xl .FormGroup__hint {
     font-size: 12px;
     line-height: 18px;
@@ -2083,107 +2035,90 @@ hr {
   padding-left: 12px;
   width: 451px;
   max-width: 100%; }
-
-@media (min-width: 600px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 600px) {
-  .container {
-    width: 673px;
-    max-width: 100%; } }
-
-@media (min-width: 900px) {
-  .container {
-    width: 879px;
-    max-width: 100%; } }
-
-@media (min-width: 1200px) {
-  .container {
-    width: 1148px;
-    max-width: 100%; } }
-
-@media (min-width: 1500px) {
-  .container {
-    width: 1148px;
-    max-width: 100%; } }
+  @media (min-width: 600px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .container {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .container {
+      width: 673px;
+      max-width: 100%; } }
+  @media (min-width: 900px) {
+    .container {
+      width: 879px;
+      max-width: 100%; } }
+  @media (min-width: 1200px) {
+    .container {
+      width: 1148px;
+      max-width: 100%; } }
+  @media (min-width: 1500px) {
+    .container {
+      width: 1148px;
+      max-width: 100%; } }
 
 .container-fluid {
   margin-right: auto;
   margin-left: auto;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .container-fluid {
-    padding-right: 12px;
-    padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .container-fluid {
+      padding-right: 12px;
+      padding-left: 12px; } }
 
 .row {
   display: flex;
   flex-wrap: wrap;
   margin-right: -12px;
   margin-left: -12px; }
-
-@media (min-width: 600px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 900px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1200px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
-
-@media (min-width: 1500px) {
-  .row {
-    margin-right: -12px;
-    margin-left: -12px; } }
+  @media (min-width: 600px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 900px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 1200px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
+  @media (min-width: 1500px) {
+    .row {
+      margin-right: -12px;
+      margin-left: -12px; } }
 
 .no-gutters {
   margin-right: 0;
   margin-left: 0; }
-
-.no-gutters > .col,
-.no-gutters > [class*="col-"] {
-  padding-right: 0;
-  padding-left: 0; }
+  .no-gutters > .col,
+  .no-gutters > [class*="col-"] {
+    padding-right: 0;
+    padding-left: 0; }
 
 .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
   position: relative;
@@ -2191,26 +2126,22 @@ hr {
   min-height: 1px;
   padding-right: 12px;
   padding-left: 12px; }
-
-@media (min-width: 600px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 900px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1200px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
-
-@media (min-width: 1500px) {
-  .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
-    padding-right: 12px;
-    padding-left: 12px; } }
+  @media (min-width: 600px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 900px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1200px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
+  @media (min-width: 1500px) {
+    .col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-1-sm, .col-2-sm, .col-3-sm, .col-4-sm, .col-5-sm, .col-6-sm, .col-7-sm, .col-8-sm, .col-9-sm, .col-10-sm, .col-11-sm, .col-12-sm, .col-sm, .col-1-md, .col-2-md, .col-3-md, .col-4-md, .col-5-md, .col-6-md, .col-7-md, .col-8-md, .col-9-md, .col-10-md, .col-11-md, .col-12-md, .col-md, .col-1-lg, .col-2-lg, .col-3-lg, .col-4-lg, .col-5-lg, .col-6-lg, .col-7-lg, .col-8-lg, .col-9-lg, .col-10-lg, .col-11-lg, .col-12-lg, .col-lg, .col-1-xl, .col-2-xl, .col-3-xl, .col-4-xl, .col-5-xl, .col-6-xl, .col-7-xl, .col-8-xl, .col-9-xl, .col-10-xl, .col-11-xl, .col-12-xl, .col-xl {
+      padding-right: 12px;
+      padding-left: 12px; } }
 
 .col {
   flex-basis: 0;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1183,8 +1183,7 @@ hr {
   outline: 0; }
 
 .TextInput:disabled,
-.TextInput[readonly],
-.TextInput--is-disabled {
+.TextInput[readonly] {
   background: #eee;
   border-color: #eee;
   color: rgba(0, 0, 0, 0.41);

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -583,6 +583,9 @@ hr {
   position: absolute;
   user-select: none; }
 
+.Checkbox--is-disabled {
+  cursor: not-allowed; }
+
 .Checkbox--medium {
   font-size: 14px;
   line-height: 21px;
@@ -858,6 +861,9 @@ hr {
     content: '';
     display: none;
     position: absolute; }
+
+.Radio--is-disabled {
+  cursor: not-allowed; }
 
 .Radio--small {
   font-size: 12px;
@@ -1182,6 +1188,7 @@ hr {
   background: #eee;
   border-color: #eee;
   color: rgba(0, 0, 0, 0.41);
+  cursor: not-allowed;
   opacity: 1; }
 
 .TextInput--has-error,

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -5797,3 +5797,6 @@ hr {
 
 .text-underline {
   text-decoration: underline !important; }
+
+.cursor-not-allowed {
+  cursor: not-allowed !important; }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -5801,6 +5801,3 @@ hr {
 
 .text-underline {
   text-decoration: underline !important; }
-
-.cursor-not-allowed {
-  cursor: not-allowed !important; }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -1176,8 +1176,7 @@ hr {
     color: rgba(0, 0, 0, 0.41);
     opacity: 1; }
 
-.TextInput:focus,
-.TextInput--is-focused {
+.TextInput:focus {
   border-color: #7feaff;
   box-shadow: 0 0 11px rgba(127, 234, 255, 0.41);
   outline: 0; }
@@ -1193,9 +1192,8 @@ hr {
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
   border-color: #f04d5d; }
-  .TextInput--has-error.TextInput:focus, .TextInput--has-error.TextInput--is-focused,
-  .FormGroup--has-error .TextInput.TextInput:focus,
-  .FormGroup--has-error .TextInput.TextInput--is-focused {
+  .TextInput--has-error.TextInput:focus,
+  .FormGroup--has-error .TextInput.TextInput:focus {
     box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
 
 .TextInput--medium,


### PR DESCRIPTION
### Buttons
- Because we use `pointer-events: none` on disabled buttons, both regular and anchor tagged buttons are wrapped with an extra div that manages the cursor. The `a` or `button` tags now have a `Button__control` class that's used to style them (instead of just `Button`, which still goes on the root element).

### Text Inputs
- This was easy, just switched the `cursor` property

### Radio/Checkboxes
- Added an `is-disabled` modifier to the wrapping element that manages the cursor

Just a thought: It seems like we're at a place where all the `is-*` modifiers are classes that should only be applied by the internal component. I don't know if there's a way to indicate a 'private' BEM modifier, but that's essentially the way these should be treated (ex. the user shouldn't be passing `Button--is-disabled` to the button component, since that doesn't change the button behavior and only applies a subset of the disabled styles).