### PR TITLE
Font antialiasing and text-color utilities

### DIFF
--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -90,8 +90,9 @@
 
 .Button--danger {
   .Button__control {
-    @include reversed-text;
     background: $red;
+    color: $white;
+    font-weight: $font-weight-bold;
 
     &:hover,
     &:focus {
@@ -112,8 +113,9 @@
 .Button--primary {
   .Button__control {
     @include depth(4);
-    @include reversed-text($font-weight: $font-weight-bold);
     background: $blue;
+    color: $white;
+    font-weight: $font-weight-bold;
 
     &:hover,
     &:focus {

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -53,6 +53,40 @@
 .text-color-reversed-secondary { color: $text-color-reversed-secondary !important; }
 .text-color-reversed-hint      { color: $text-color-reversed-hint      !important; }
 
+.text-color-orange { color: $orange !important; }
+.text-color-orange-100 { color: $orange-100 !important; }
+.text-color-orange-200 { color: $orange-200 !important; }
+.text-color-orange-300 { color: $orange-300 !important; }
+.text-color-orange-400 { color: $orange-400 !important; }
+.text-color-orange-500 { color: $orange-500 !important; }
+
+.text-color-red { color: $red !important; }
+.text-color-red-100 { color: $red-100 !important; }
+.text-color-red-200 { color: $red-200 !important; }
+.text-color-red-300 { color: $red-300 !important; }
+.text-color-red-400 { color: $red-400 !important; }
+.text-color-red-500 { color: $red-500 !important; }
+
+.text-color-purple { color: $purple !important; }
+.text-color-purple-100 { color: $purple-100 !important; }
+.text-color-purple-200 { color: $purple-200 !important; }
+.text-color-purple-300 { color: $purple-300 !important; }
+.text-color-purple-400 { color: $purple-400 !important; }
+.text-color-purple-500 { color: $purple-500 !important; }
+
+.text-color-blue { color: $blue !important; }
+.text-color-blue-100 { color: $blue-100 !important; }
+.text-color-blue-200 { color: $blue-200 !important; }
+.text-color-blue-300 { color: $blue-300 !important; }
+.text-color-blue-400 { color: $blue-400 !important; }
+.text-color-blue-500 { color: $blue-500 !important; }
+
+.text-color-green { color: $green !important; }
+.text-color-green-100 { color: $green-100 !important; }
+.text-color-green-200 { color: $green-200 !important; }
+.text-color-green-300 { color: $green-300 !important; }
+.text-color-green-400 { color: $green-400 !important; }
+.text-color-green-500 { color: $green-500 !important; }
 
 // ------------------------------
 // Text weight/style utilities

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -45,6 +45,8 @@
 // Text color utilities
 // ------------------------------
 
+.text-color-inherit { color: inherit !important; }
+
 .text-color-primary   { color: $text-color-primary   !important; }
 .text-color-secondary { color: $text-color-secondary !important; }
 .text-color-hint      { color: $text-color-hint      !important; }
@@ -87,6 +89,16 @@
 .text-color-green-300 { color: $green-300 !important; }
 .text-color-green-400 { color: $green-400 !important; }
 .text-color-green-500 { color: $green-500 !important; }
+
+.text-color-gray-100 { color: $gray-100 !important; }
+.text-color-gray-200 { color: $gray-200 !important; }
+.text-color-gray-300 { color: $gray-300 !important; }
+.text-color-gray-400 { color: $gray-400 !important; }
+.text-color-gray-500 { color: $gray-500 !important; }
+.text-color-gray-600 { color: $gray-600 !important; }
+.text-color-gray-700 { color: $gray-700 !important; }
+.text-color-gray-800 { color: $gray-800 !important; }
+
 
 // ------------------------------
 // Text weight/style utilities

--- a/library/utilities/typography/typography.jsx
+++ b/library/utilities/typography/typography.jsx
@@ -79,7 +79,7 @@ function TypographyUtilities() {
       <hr className="my7" />
 
       <h4>Colors</h4>
-      <div className="d-flex-sm">
+      <div className="d-flex flex-wrap">
         <div className="mr7-sm p5">
           <Label>.text-color-primary<br />$text-color-primary</Label>
           <p className="text-color-primary">◼︎ Primary color</p>
@@ -106,6 +106,22 @@ function TypographyUtilities() {
           </Label>
           <p className="text-color-reversed-hint">◼︎ Reversed hint color</p>
         </div>
+      </div>
+
+      <div className="d-flex flex-wrap mt5">
+        {['orange', 'red', 'purple', 'blue', 'green'].map(color => (
+          <div className="mr7-sm p5" key={color}>
+            <Label>.text-color-{color} ${color}</Label>
+            <p className={`text-color-${color}`}>◼︎ {color}</p>
+            {['100', '200', '300', '400', '500'].map(shade => (
+              <div key={`${color}-${shade}`}>
+                <hr />
+                <Label>.text-color-{color}-{shade} ${color}-{shade}</Label>
+                <p className={`text-color-${color}-${shade}`}>︎◼︎ {color} {shade}</p>
+              </div>
+            ))}
+          </div>
+        ))}
       </div>
 
       <hr className="my7" />

--- a/library/utilities/typography/typography.jsx
+++ b/library/utilities/typography/typography.jsx
@@ -124,6 +124,18 @@ function TypographyUtilities() {
         ))}
       </div>
 
+      <div className="d-flex mt5 p5">
+        <div>
+          {['100', '200', '300', '400', '500', '600', '700', '800'].map(shade => (
+            <div key={`gray-${shade}`}>
+              {shade !== '100' && <hr />}
+              <Label>.text-color-gray-{shade} $gray-{shade}</Label>
+              <p className={`text-color-gray-${shade}`}>︎◼︎ gray {shade}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
       <hr className="my7" />
 
       <h4>Weight &amp; style</h4>

--- a/library/utilities/typography/typography.jsx
+++ b/library/utilities/typography/typography.jsx
@@ -85,7 +85,7 @@ function TypographyUtilities() {
           <p className="text-color-primary">◼︎ Primary color</p>
           <hr />
           <Label>.text-color-secondary<br />$text-color-secondary</Label>
-          <p className="text-color-secondary">︎◼︎ Secondary color</p>
+          <p className="text-color-secondary">◼︎ Secondary color</p>
           <hr />
           <Label>.text-color-hint<br />$text-color-hint</Label>
           <p className="text-color-hint">◼︎ Hint color</p>
@@ -117,7 +117,7 @@ function TypographyUtilities() {
               <div key={`${color}-${shade}`}>
                 <hr />
                 <Label>.text-color-{color}-{shade} ${color}-{shade}</Label>
-                <p className={`text-color-${color}-${shade}`}>︎◼︎ {color} {shade}</p>
+                <p className={`text-color-${color}-${shade}`}>◼︎ {color} {shade}</p>
               </div>
             ))}
           </div>
@@ -130,7 +130,7 @@ function TypographyUtilities() {
             <div key={`gray-${shade}`}>
               {shade !== '100' && <hr />}
               <Label>.text-color-gray-{shade} $gray-{shade}</Label>
-              <p className={`text-color-gray-${shade}`}>︎◼︎ gray {shade}</p>
+              <p className={`text-color-gray-${shade}`}>◼︎ gray {shade}</p>
             </div>
           ))}
         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminohealth/phenotypes",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Amino's design language and front-end component library",
   "dependencies": {
     "classnames": "^2.2.5",

--- a/styles/_reboot.scss
+++ b/styles/_reboot.scss
@@ -70,6 +70,10 @@ body {
   line-height: $line-height-base;
   color: $body-color;
   background-color: $body-bg; // 2
+  @if $font-antialiasing {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
 }
 
 // Suppress the focus outline on elements that cannot be accessed via keyboard.

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -251,6 +251,8 @@ $font-family-sans-serif: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI"
 $font-family-monospace:  Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !default;
 $font-family-base:       $font-family-sans-serif !default;
 
+$font-antialiasing: true !default;
+
 $font-size-base: $modular-scale-base-px !default;
 
 $font-weight-normal: normal !default;

--- a/styles/mixins/_type.scss
+++ b/styles/mixins/_type.scss
@@ -25,20 +25,6 @@
   @return round($font-size * $line-height-ratio);
 }
 
-// Reversed text (white on dark)
-@mixin reversed-text(
-  $color: $white,
-  $font-weight: $font-weight-normal
-) {
-  color: $color;
-  font-weight: $font-weight;
-
-  // Bold reversed text looks very fat with default antialiasing
-  @if $font-weight == $font-weight-bold {
-    -webkit-font-smoothing: antialiased;
-  }
-}
-
 
 // ------------------------------
 // Text mixins

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -87,7 +87,9 @@ body {
   font-weight: normal;
   line-height: 1.49271;
   color: rgba(0, 0, 0, 0.86);
-  background-color: #fff; }
+  background-color: #fff;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale; }
 
 [tabindex="-1"]:focus {
   outline: none !important; }
@@ -427,9 +429,9 @@ hr {
   cursor: not-allowed; }
 
 .Button--danger .Button__control {
+  background: #f04d5d;
   color: #fff;
-  font-weight: normal;
-  background: #f04d5d; }
+  font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
     background: #ee3548;
     color: #fff; }
@@ -440,10 +442,9 @@ hr {
 
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
+  background: #16b8e0;
   color: #fff;
-  font-weight: bold;
-  -webkit-font-smoothing: antialiased;
-  background: #16b8e0; }
+  font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
     background: #14a5c9;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -5875,6 +5875,9 @@ hr {
     letter-spacing: 1.71429px !important;
     font-weight: bold !important; } }
 
+.text-color-inherit {
+  color: inherit !important; }
+
 .text-color-primary {
   color: rgba(0, 0, 0, 0.86) !important; }
 
@@ -5892,6 +5895,120 @@ hr {
 
 .text-color-reversed-hint {
   color: rgba(255, 255, 255, 0.59) !important; }
+
+.text-color-orange {
+  color: #fc8626 !important; }
+
+.text-color-orange-100 {
+  color: #ffc67f !important; }
+
+.text-color-orange-200 {
+  color: #fc8626 !important; }
+
+.text-color-orange-300 {
+  color: #cd5000 !important; }
+
+.text-color-orange-400 {
+  color: #992800 !important; }
+
+.text-color-orange-500 {
+  color: #631000 !important; }
+
+.text-color-red {
+  color: #f04d5d !important; }
+
+.text-color-red-100 {
+  color: #ff979a !important; }
+
+.text-color-red-200 {
+  color: #f04d5d !important; }
+
+.text-color-red-300 {
+  color: #bd2b43 !important; }
+
+.text-color-red-400 {
+  color: #8c092c !important; }
+
+.text-color-red-500 {
+  color: #4a001e !important; }
+
+.text-color-purple {
+  color: #853b94 !important; }
+
+.text-color-purple-100 {
+  color: #e39ae3 !important; }
+
+.text-color-purple-200 {
+  color: #b35dba !important; }
+
+.text-color-purple-300 {
+  color: #853b94 !important; }
+
+.text-color-purple-400 {
+  color: #58166e !important; }
+
+.text-color-purple-500 {
+  color: #2f0047 !important; }
+
+.text-color-blue {
+  color: #16b8e0 !important; }
+
+.text-color-blue-100 {
+  color: #7feaff !important; }
+
+.text-color-blue-200 {
+  color: #16b8e0 !important; }
+
+.text-color-blue-300 {
+  color: #008ab3 !important; }
+
+.text-color-blue-400 {
+  color: #005678 !important; }
+
+.text-color-blue-500 {
+  color: #00253f !important; }
+
+.text-color-green {
+  color: #03ab8c !important; }
+
+.text-color-green-100 {
+  color: #89f0cf !important; }
+
+.text-color-green-200 {
+  color: #2dcfa1 !important; }
+
+.text-color-green-300 {
+  color: #03ab8c !important; }
+
+.text-color-green-400 {
+  color: #007868 !important; }
+
+.text-color-green-500 {
+  color: #003f3e !important; }
+
+.text-color-gray-100 {
+  color: #f9f9f9 !important; }
+
+.text-color-gray-200 {
+  color: #eee !important; }
+
+.text-color-gray-300 {
+  color: #dbdbdb !important; }
+
+.text-color-gray-400 {
+  color: #c1c1c1 !important; }
+
+.text-color-gray-500 {
+  color: #969696 !important; }
+
+.text-color-gray-600 {
+  color: #777 !important; }
+
+.text-color-gray-700 {
+  color: #4d4d4d !important; }
+
+.text-color-gray-800 {
+  color: #232323 !important; }
 
 .text-weight-bold {
   font-weight: bold !important; }


### PR DESCRIPTION
- adds `-webkit-font-smoothing: antialiasing` and `-moz-osx-font-smoothing: grayscale;` (for firefox) to the `<body>`. The non-vendor-prefixed `font-smooth` property doesn't appear to do anything (I tried in all the main browsers), so left that out.
- adds text color utilities, with docs

### breaking changes

- the `reversed-text` mixin has been removed (it was mainly adding antialiasing for reversed text, which is no longer necessary)
- antialiasing of text is kinda breaking? since the style of all text is slightly changing