### PR TITLE
Add support for setting the width of buttons with our normal sizing classes

### DIFF
--- a/library/components/button/README.md
+++ b/library/components/button/README.md
@@ -41,6 +41,10 @@ Javascript:
 ```
 Rendered markup:
 ```html
-<button class="Button" type="button">Click me!</button>
-<a href="#" class="Button" role="button">No, click me!</a>
+<div class="Button">
+    <button class="Button__control" type="button">Click me!</button>
+</div>
+<div class="Button">
+  <a href="#" class="Button__control" role="button">No, click me!</a>
+</div>
 ```

--- a/library/components/button/README.md
+++ b/library/components/button/README.md
@@ -42,7 +42,7 @@ Javascript:
 Rendered markup:
 ```html
 <div class="Button">
-    <button class="Button__control" type="button">Click me!</button>
+  <button class="Button__control" type="button">Click me!</button>
 </div>
 <div class="Button">
   <a href="#" class="Button__control" role="button">No, click me!</a>

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -41,6 +41,7 @@
   transition: all .2s ease-out;
   vertical-align: middle;
   white-space: nowrap;
+  width: 100%;
 
   // scss-lint:disable VendorPrefix
   // TODO: Add Autoprefixer

--- a/library/components/button/button.spec.jsx
+++ b/library/components/button/button.spec.jsx
@@ -21,19 +21,23 @@ function mockSyntheticEvent() {
 describe('Button', function () {
   it('should render a button tag', function () {
     const wrapper = mount(<Button />);
+    expect(wrapper.hasClass('Button')).to.be.true;
+
     const trueButton = wrapper.find('button');
 
     expect(trueButton).to.have.length(1);
-    expect(trueButton.hasClass('Button')).to.be.true;
+    expect(trueButton.hasClass('Button__control')).to.be.true;
     expect(trueButton.props().type).to.equal('button');
   });
 
   it('should render an anchor tag', function () {
     const wrapper = mount(<Button href="/" />);
+    expect(wrapper.hasClass('Button')).to.be.true;
+
     const anchorButton = wrapper.find('a');
 
     expect(anchorButton).to.have.length(1);
-    expect(anchorButton.hasClass('Button')).to.be.true;
+    expect(anchorButton.hasClass('Button__control')).to.be.true;
     expect(anchorButton.props().role).to.equal('button');
   });
 
@@ -73,7 +77,7 @@ describe('Button', function () {
     const wrapper = mount(<Button onClick={onClickSpy} disabled />);
     const trueButton = wrapper.find('button');
 
-    expect(trueButton.hasClass('Button--is-disabled')).to.be.true;
+    expect(wrapper.hasClass('Button--is-disabled')).to.be.true;
     expect(trueButton.props().disabled).to.be.true;
 
     trueButton.simulate('click');
@@ -86,7 +90,7 @@ describe('Button', function () {
     const wrapper = mount(<Button href="/" onClick={onClickSpy} disabled />);
     const anchorButton = wrapper.find('a');
 
-    expect(anchorButton.hasClass('Button--is-disabled')).to.be.true;
+    expect(wrapper.hasClass('Button--is-disabled')).to.be.true;
     expect(anchorButton.props().tabIndex).to.equal(-1);
 
     const eventSpy = mockSyntheticEvent();

--- a/library/components/text_input/text_input.spec.jsx
+++ b/library/components/text_input/text_input.spec.jsx
@@ -42,7 +42,7 @@ describe('TextInput', function () {
     expect(inputProps['aria-label']).to.equal('label');
     expect(inputProps.autoComplete).to.equal('autoComplete');
     expect(inputProps.autoFocus).to.equal('autoFocus');
-    expect(inputProps.className).to.equal('className TextInput TextInput--is-disabled');
+    expect(inputProps.className).to.equal('className TextInput');
     expect(inputProps.form).to.equal('form');
     expect(inputProps.disabled).to.equal('disabled');
     expect(inputProps.id).to.equal('id');

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -394,6 +394,7 @@ hr {
   transition: all .2s ease-out;
   vertical-align: middle;
   white-space: nowrap;
+  width: 100%;
   -moz-user-select: none;
   -ms-user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
This adds `width: 100%` to the `Button__control` class so the inner button or anchor element will expand to the size of its wrapping `Button` div.

We could consider adding something like `height: inherit` to `Button__control` as well, but I don't see any reason we'd set the height outside of the button sizing classes currently.

Also updated the tests and the button docs usage section.