### PR TITLE
version 7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminohealth/phenotypes",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Amino's design language and front-end component library",
   "dependencies": {
     "classnames": "^2.2.5",


### PR DESCRIPTION
Publishing a new version with the babel 7 stuff. It's a breaking change b/c of the switch from `module.exports` to `export default`. Someone could have been relying on that specific export structure before.