### PR TITLE
Fix spacing on small/medium radios

### DIFF
--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -45,7 +45,7 @@
   $dot-size: modular-scale-px(-6);
 
   @include text-4;
-  padding-left: $size + $spacer-3;
+  padding-left: $size + $spacer-2;
 
   .Radio__indicator {
     height: $size;
@@ -139,7 +139,7 @@
   &::after {
     background-color: $white;
     border-radius: 50%;
-    content: '';
+    content: "";
     display: none;
     position: absolute;
   }
@@ -154,12 +154,22 @@
     @include media-breakpoint-up($breakpoint) {
       $suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);
 
-      .Radio--small#{$suffix} { @include radio-small; }
-      .Radio--medium#{$suffix} { @include radio-medium; }
-      .Radio--large#{$suffix} { @include radio-large; }
+      .Radio--small#{$suffix} {
+        @include radio-small;
+      }
+      .Radio--medium#{$suffix} {
+        @include radio-medium;
+      }
+      .Radio--large#{$suffix} {
+        @include radio-large;
+      }
     }
   }
 } @else {
-  .Radio--small { @include radio-small; }
-  .Radio--large { @include radio-large; }
+  .Radio--small {
+    @include radio-small;
+  }
+  .Radio--large {
+    @include radio-large;
+  }
 }

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -3,7 +3,7 @@
   $dot-size: modular-scale-px(-7);
 
   @include text-1;
-  padding-left: $size + $spacer-1;
+  padding-left: $size + $spacer-2;
 
   .Radio__indicator {
     height: $size;
@@ -24,7 +24,7 @@
   $dot-size: modular-scale-px(-7);
 
   @include text-2;
-  padding-left: $size + $spacer-1;
+  padding-left: $size + $spacer-2;
 
   .Radio__indicator {
     height: $size;
@@ -45,7 +45,7 @@
   $dot-size: modular-scale-px(-6);
 
   @include text-4;
-  padding-left: $size + $spacer-2;
+  padding-left: $size + $spacer-3;
 
   .Radio__indicator {
     height: $size;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -7,30 +7,30 @@
 /**
  * @license
  * MyFonts Webfont Build ID 3386717, 2017-05-09T18:37:44-0400
- *
+ * 
  * The fonts listed in this notice are subject to the End User License
- * Agreement(s) entered into by the website owner. All other parties are
+ * Agreement(s) entered into by the website owner. All other parties are 
  * explicitly restricted from using the Licensed Webfonts(s).
- *
+ * 
  * You may obtain a valid license at the URLs below.
- *
+ * 
  * Webfont: Sailec-Bold by Type Dynamic
  * URL: https://www.myfonts.com/fonts/typedynamic/sailec/bold/
- *
+ * 
  * Webfont: Sailec-BoldItalic by Type Dynamic
  * URL: https://www.myfonts.com/fonts/typedynamic/sailec/bold-italic/
- *
+ * 
  * Webfont: Sailec-Regular by Type Dynamic
  * URL: https://www.myfonts.com/fonts/typedynamic/sailec/regular/
- *
+ * 
  * Webfont: Sailec-RegularItalic by Type Dynamic
  * URL: https://www.myfonts.com/fonts/typedynamic/sailec/regular-italic/
- *
- *
+ * 
+ * 
  * License: https://www.myfonts.com/viewlicense?type=web&buildid=3386717
  * Licensed pageviews: 20,000
  * Webfonts copyright: Copyright &#x00A9; 2014 by Type Dynamic. All rights reserved.
- *
+ * 
  * © 2017 MyFonts Inc
 */
 /* @import must be at top of file, otherwise CSS will not work */
@@ -869,7 +869,7 @@ hr {
   .Radio__indicator::after {
     background-color: #fff;
     border-radius: 50%;
-    content: '';
+    content: "";
     display: none;
     position: absolute; }
 
@@ -913,7 +913,7 @@ hr {
   line-height: 27px;
   letter-spacing: 0px;
   font-weight: normal;
-  padding-left: 32px; }
+  padding-left: 28px; }
   .Radio--large .Radio__indicator {
     height: 21px;
     top: 2px;
@@ -960,7 +960,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 32px; }
+    padding-left: 28px; }
     .Radio--large-sm .Radio__indicator {
       height: 21px;
       top: 2px;
@@ -1007,7 +1007,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 32px; }
+    padding-left: 28px; }
     .Radio--large-md .Radio__indicator {
       height: 21px;
       top: 2px;
@@ -1054,7 +1054,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 32px; }
+    padding-left: 28px; }
     .Radio--large-lg .Radio__indicator {
       height: 21px;
       top: 2px;
@@ -1101,7 +1101,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 32px; }
+    padding-left: 28px; }
     .Radio--large-xl .Radio__indicator {
       height: 21px;
       top: 2px;

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -810,7 +810,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  padding-left: 21px;
+  padding-left: 23px;
   display: inline-block;
   margin: 0;
   position: relative; }
@@ -881,7 +881,7 @@ hr {
   line-height: 18px;
   letter-spacing: 0px;
   font-weight: normal;
-  padding-left: 19px; }
+  padding-left: 21px; }
   .Radio--small .Radio__indicator {
     height: 14px;
     top: 1px;
@@ -897,7 +897,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  padding-left: 21px; }
+  padding-left: 23px; }
   .Radio--medium .Radio__indicator {
     height: 16px;
     top: 1px;
@@ -913,7 +913,7 @@ hr {
   line-height: 27px;
   letter-spacing: 0px;
   font-weight: normal;
-  padding-left: 28px; }
+  padding-left: 32px; }
   .Radio--large .Radio__indicator {
     height: 21px;
     top: 2px;
@@ -930,7 +930,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 19px; }
+    padding-left: 21px; }
     .Radio--small-sm .Radio__indicator {
       height: 14px;
       top: 1px;
@@ -945,7 +945,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 21px; }
+    padding-left: 23px; }
     .Radio--medium-sm .Radio__indicator {
       height: 16px;
       top: 1px;
@@ -960,7 +960,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 28px; }
+    padding-left: 32px; }
     .Radio--large-sm .Radio__indicator {
       height: 21px;
       top: 2px;
@@ -977,7 +977,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 19px; }
+    padding-left: 21px; }
     .Radio--small-md .Radio__indicator {
       height: 14px;
       top: 1px;
@@ -992,7 +992,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 21px; }
+    padding-left: 23px; }
     .Radio--medium-md .Radio__indicator {
       height: 16px;
       top: 1px;
@@ -1007,7 +1007,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 28px; }
+    padding-left: 32px; }
     .Radio--large-md .Radio__indicator {
       height: 21px;
       top: 2px;
@@ -1024,7 +1024,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 19px; }
+    padding-left: 21px; }
     .Radio--small-lg .Radio__indicator {
       height: 14px;
       top: 1px;
@@ -1039,7 +1039,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 21px; }
+    padding-left: 23px; }
     .Radio--medium-lg .Radio__indicator {
       height: 16px;
       top: 1px;
@@ -1054,7 +1054,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 28px; }
+    padding-left: 32px; }
     .Radio--large-lg .Radio__indicator {
       height: 21px;
       top: 2px;
@@ -1071,7 +1071,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 19px; }
+    padding-left: 21px; }
     .Radio--small-xl .Radio__indicator {
       height: 14px;
       top: 1px;
@@ -1086,7 +1086,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 21px; }
+    padding-left: 23px; }
     .Radio--medium-xl .Radio__indicator {
       height: 16px;
       top: 1px;
@@ -1101,7 +1101,7 @@ hr {
     line-height: 27px;
     letter-spacing: 0px;
     font-weight: normal;
-    padding-left: 28px; }
+    padding-left: 32px; }
     .Radio--large-xl .Radio__indicator {
       height: 21px;
       top: 2px;


### PR DESCRIPTION
The text was a little too close to the radio on small/medium versions. Updated to use the same spacing as checkboxes.

![Screen Shot 2019-11-26 at 2 30 58 PM](https://user-images.githubusercontent.com/147870/69678281-fc584b00-1059-11ea-8963-4bf71d6ed5e1.png)
