### PR TITLE
Add more sizes (10, 11, 12, 13)

### DIFF
--- a/library/utilities/sizing/_sizing.scss
+++ b/library/utilities/sizing/_sizing.scss
@@ -20,10 +20,12 @@
       $bp: breakpoint-suffix($breakpoint, $grid-breakpoints);
 
       @each $dimension in (width, height) {
-        @for $i from 1 through length($spacers) {
+        @for $i from 1 through length($sizers) {
           $size: $i - 1;
-          $length: nth($spacers, $i);
-          .#{$dimension}-#{$size}#{$bp} { #{$dimension}: $length !important; }
+          $length: nth($sizers, $i);
+          .#{$dimension}-#{$size}#{$bp} {
+            #{$dimension}: $length !important;
+          }
         }
 
         .#{$dimension}-full#{$bp} { #{$dimension}: 100% !important; }

--- a/styles/_variables.scss
+++ b/styles/_variables.scss
@@ -155,6 +155,10 @@ $spacer-6: modular-scale-px(6)  !default; // 36px
 $spacer-7: modular-scale-px(9)  !default; // 53px
 $spacer-8: modular-scale-px(12) !default; // 79px
 $spacer-9: modular-scale-px(15) !default; // 119px
+$spacer-10: modular-scale-px(18) !default; // 177px
+$spacer-11: modular-scale-px(21) !default; // 264px
+$spacer-12: modular-scale-px(24) !default; // 394px
+$spacer-13: modular-scale-px(27) !default; // 589px
 
 // Keep this in sync with the above variables for the utilities to work
 $spacers: (
@@ -167,7 +171,24 @@ $spacers: (
   $spacer-6,
   $spacer-7,
   $spacer-8,
+  $spacer-9
+) !default;
+
+$sizers: (
+  $spacer-0,
+  $spacer-1,
+  $spacer-2,
+  $spacer-3,
+  $spacer-4,
+  $spacer-5,
+  $spacer-6,
+  $spacer-7,
+  $spacer-8,
   $spacer-9,
+  $spacer-10,
+  $spacer-11,
+  $spacer-12,
+  $spacer-13
 ) !default;
 
 // This variable affects the `.h-*` and `.w-*` classes.

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -2936,6 +2936,18 @@ hr {
 .width-9 {
   width: 119px !important; }
 
+.width-10 {
+  width: 177px !important; }
+
+.width-11 {
+  width: 264px !important; }
+
+.width-12 {
+  width: 394px !important; }
+
+.width-13 {
+  width: 589px !important; }
+
 .width-full {
   width: 100% !important; }
 
@@ -2969,6 +2981,18 @@ hr {
 .height-9 {
   height: 119px !important; }
 
+.height-10 {
+  height: 177px !important; }
+
+.height-11 {
+  height: 264px !important; }
+
+.height-12 {
+  height: 394px !important; }
+
+.height-13 {
+  height: 589px !important; }
+
 .height-full {
   height: 100% !important; }
 
@@ -2993,6 +3017,14 @@ hr {
     width: 79px !important; }
   .width-9-sm {
     width: 119px !important; }
+  .width-10-sm {
+    width: 177px !important; }
+  .width-11-sm {
+    width: 264px !important; }
+  .width-12-sm {
+    width: 394px !important; }
+  .width-13-sm {
+    width: 589px !important; }
   .width-full-sm {
     width: 100% !important; }
   .height-0-sm {
@@ -3015,6 +3047,14 @@ hr {
     height: 79px !important; }
   .height-9-sm {
     height: 119px !important; }
+  .height-10-sm {
+    height: 177px !important; }
+  .height-11-sm {
+    height: 264px !important; }
+  .height-12-sm {
+    height: 394px !important; }
+  .height-13-sm {
+    height: 589px !important; }
   .height-full-sm {
     height: 100% !important; } }
 
@@ -3039,6 +3079,14 @@ hr {
     width: 79px !important; }
   .width-9-md {
     width: 119px !important; }
+  .width-10-md {
+    width: 177px !important; }
+  .width-11-md {
+    width: 264px !important; }
+  .width-12-md {
+    width: 394px !important; }
+  .width-13-md {
+    width: 589px !important; }
   .width-full-md {
     width: 100% !important; }
   .height-0-md {
@@ -3061,6 +3109,14 @@ hr {
     height: 79px !important; }
   .height-9-md {
     height: 119px !important; }
+  .height-10-md {
+    height: 177px !important; }
+  .height-11-md {
+    height: 264px !important; }
+  .height-12-md {
+    height: 394px !important; }
+  .height-13-md {
+    height: 589px !important; }
   .height-full-md {
     height: 100% !important; } }
 
@@ -3085,6 +3141,14 @@ hr {
     width: 79px !important; }
   .width-9-lg {
     width: 119px !important; }
+  .width-10-lg {
+    width: 177px !important; }
+  .width-11-lg {
+    width: 264px !important; }
+  .width-12-lg {
+    width: 394px !important; }
+  .width-13-lg {
+    width: 589px !important; }
   .width-full-lg {
     width: 100% !important; }
   .height-0-lg {
@@ -3107,6 +3171,14 @@ hr {
     height: 79px !important; }
   .height-9-lg {
     height: 119px !important; }
+  .height-10-lg {
+    height: 177px !important; }
+  .height-11-lg {
+    height: 264px !important; }
+  .height-12-lg {
+    height: 394px !important; }
+  .height-13-lg {
+    height: 589px !important; }
   .height-full-lg {
     height: 100% !important; } }
 
@@ -3131,6 +3203,14 @@ hr {
     width: 79px !important; }
   .width-9-xl {
     width: 119px !important; }
+  .width-10-xl {
+    width: 177px !important; }
+  .width-11-xl {
+    width: 264px !important; }
+  .width-12-xl {
+    width: 394px !important; }
+  .width-13-xl {
+    width: 589px !important; }
   .width-full-xl {
     width: 100% !important; }
   .height-0-xl {
@@ -3153,6 +3233,14 @@ hr {
     height: 79px !important; }
   .height-9-xl {
     height: 119px !important; }
+  .height-10-xl {
+    height: 177px !important; }
+  .height-11-xl {
+    height: 264px !important; }
+  .height-12-xl {
+    height: 394px !important; }
+  .height-13-xl {
+    height: 589px !important; }
   .height-full-xl {
     height: 100% !important; } }
 


### PR DESCRIPTION
I want to be able to do this in web:

```jsx
<div className="height-12 height-auto-sm">
```

But that doesn't work, because `height-12` is defined in web, so it's more specific than `height-auto-sm` which is defined in phenotypes and thus comes earlier in the stylesheet.

I'm only adding these sizes to our height/width utilities (not our margin, padding, etc. utilities), so it's not a huge addition.