### PR TITLE
Bugfix: Button link style

### DIFF
--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -136,7 +136,7 @@
 // Link style button
 // -----------------
 
-.Button--link .Button__control {
+.Button--link {
   .Button__control {
     background: transparent;
     color: $blue;


### PR DESCRIPTION
Currently these don't render as links:
![image](https://user-images.githubusercontent.com/1026059/85591068-d39d3180-b5f9-11ea-8578-dd67877fba24.png)


I think this was an accidentally doubled `Button__control` class in the selector.

Note: Having trouble building currently, so haven't tested this yet.