### PR TITLE
Add initial support for theming via variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $grid-breakpoints: (
 
 The `_mixins.scss` file contains imports for functions and mixins that are used by other modules and components. Actual implementations should go in `styles/mixins`. E.g. `styles/mixins/_type.scss` contains both functions and mixins that help with typography.
 
-The `_theme_config.scss` file contains a css ruleset that defines the theming css variables that phenotypes uses. These are defined as css custom properties and allow custom themes for Phenotypes. Please see the [Theming README](/THEMING.md) for more info
+The `_theme_config.scss` file contains a css ruleset that defines the theming css variables that phenotypes uses. These are defined as css custom properties and allow custom themes for Phenotypes. Please see the [Theming guide](/guides/11-theming.md) for more info
 
 Phenotypes uses a slightly modified version of Bootstrap 4's reboot. [Read more about that.](https://v4-alpha.getbootstrap.com/content/reboot/)
 
@@ -152,11 +152,11 @@ $ npm install @aminohealth/phenotypes --save
 
 The recommended way to use the styles for phenotypes is to import the scss entrypoint phenotypes.scss in your own project. When installed via npm this will be located at `@aminohealth/phenotypes/styles/phenotypes.scss`. This does require your project to use [Sass](https://sass-lang.com/). This is; however, not required and for that reason we also provide plain old css that you are able to use.
 
-**NOTE**  By default the phenotypes.scss entry point when compiled will include CSS variables in the output. CSS variables are required for custom themes. CSS variables will work fine for all evergreen browsers; however, if you need to support a browser that does not support CSS variables (IE) or do not require a custom theme, you can compile the css variables away (Or see the [theming docs](./THEMING.md) for supporting IE .) CSS variables can be compiled away easily by post-processing via [postcss](https://postcss.org/) and using the [postcss-preset-env](https://preset-env.cssdb.org/) plugin. An example of how to do this is can be seen in our own build process when we compile the phenotypes.scss file to plain old css [here](./scripts/compileScss.js#L40-L48).
+**NOTE**  By default the phenotypes.scss entry point when compiled will include CSS variables in the output. CSS variables are required for custom themes. CSS variables will work fine for all evergreen browsers; however, if you need to support a browser that does not support CSS variables (IE) or do not require a custom theme, you can compile the css variables away (Or see the [Theming guide](/guides/11-theming.md) for supporting IE .) CSS variables can be compiled away easily by post-processing via [postcss](https://postcss.org/) and using the [postcss-preset-env](https://preset-env.cssdb.org/) plugin. An example of how to do this is can be seen in our own build process when we compile the phenotypes.scss file to plain old css [here](./scripts/compileScss.js#L40-L48).
 
 ### CSS
 
-If you do not want to use sass there are two different css files that Phenotypes provides. The most straightforward of which is located at `@aminohealth/dist/css/phenotypes.css` when installed via npm. The other file is a themable css file that is located at `@aminohealth/dist/css/phenotypes.themable.css`. This file uses CSS variables to set theme variables and propagate those values to the Phenotypes styling. More information on this can be found in the [theming docs](./THEMING.md).
+If you do not want to use sass there are two different css files that Phenotypes provides. The most straightforward of which is located at `@aminohealth/dist/css/phenotypes.css` when installed via npm. The other file is a themable css file that is located at `@aminohealth/dist/css/phenotypes.themable.css`. This file uses CSS variables to set theme variables and propagate those values to the Phenotypes styling. More information on this can be found in the [Theming guide](/guides/11-theming.md).
 
 ### Peer Dependencies
 
@@ -183,7 +183,7 @@ ReactDOM.render(
 
 ## Theming
 
-Phenotypes allows you to theme the css and component library to suit your needs. Please see the [theming docs](/THEMING.md) for more information on how to customize and theme phenotypes.
+Phenotypes allows you to theme the css and component library to suit your needs. Please see the [Theming guide](/guides/11-theming.md) for more information on how to customize and theme phenotypes.
 
 [npm-url]: https://www.npmjs.com/package/@aminohealth/phenotypes
 [npm-version-image]: https://img.shields.io/npm/v/@aminohealth/phenotypes.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ The SASS file organization scheme is loosely based on Bootstrap 4. The entry poi
 2. Feature toggles
 3. Modular scale
 4. Variables and mixins
-5. Reboot
-6. Typography
-7. Components
-8. Utilities
+5. Theme CSS variables
+6. Reboot
+7. Typography
+8. Components
+9. Utilities
 
 Webfonts are imported first, because they're pulled in as a raw .css import. The webfont file has a CSS `@import` directive at the top, which must come first in the compiled stylesheet.
 
@@ -105,6 +106,8 @@ $grid-breakpoints: (
 ```
 
 The `_mixins.scss` file contains imports for functions and mixins that are used by other modules and components. Actual implementations should go in `styles/mixins`. E.g. `styles/mixins/_type.scss` contains both functions and mixins that help with typography.
+
+The `_theme_config.scss` file contains a css ruleset that defines the theming css variables that phenotypes uses. These are defined as css custom properties and allow custom themes for Phenotypes. Please see the [Theming README](/THEMING.md) for more info
 
 Phenotypes uses a slightly modified version of Bootstrap 4's reboot. [Read more about that.](https://v4-alpha.getbootstrap.com/content/reboot/)
 
@@ -145,6 +148,18 @@ The following command will install Phenotypes into `@aminohealth/phenotypes`:
 $ npm install @aminohealth/phenotypes --save
 ```
 
+### SASS
+
+The recommended way to use the styles for phenotypes is to import the scss entrypoint phenotypes.scss in your own project. When installed via npm this will be located at `@aminohealth/phenotypes/styles/phenotypes.scss`. This does require your project to use [Sass](https://sass-lang.com/). This is; however, not required and for that reason we also provide plain old css that you are able to use.
+
+**NOTE**  By default the phenotypes.scss entry point when compiled will include CSS variables in the output. CSS variables are required for custom themes. CSS variables will work fine for all evergreen browsers; however, if you need to support a browser that does not support CSS variables (IE) or do not require a custom theme, you can compile the css variables away (Or see the [theming docs](./THEMING.md) for supporting IE .) CSS variables can be compiled away easily by post-processing via [postcss](https://postcss.org/) and using the [postcss-preset-env](https://preset-env.cssdb.org/) plugin. An example of how to do this is can be seen in our own build process when we compile the phenotypes.scss file to plain old css [here](./scripts/compileScss.js#L40-L48).
+
+### CSS
+
+If you do not want to use sass there are two different css files that Phenotypes provides. The most straightforward of which is located at `@aminohealth/dist/css/phenotypes.css` when installed via npm. The other file is a themable css file that is located at `@aminohealth/dist/css/phenotypes.themable.css`. This file uses CSS variables to set theme variables and propagate those values to the Phenotypes styling. More information on this can be found in the [theming docs](./THEMING.md).
+
+### Peer Dependencies
+
 Phenotypes relies on a few peer dependencies that are exluded from the final build in order to ensure there are no duplicate libraries that are shipped when you use it within your application. You will need to install these alongside Phenotypes to ensure that the React components work correctly. These include:
 
 * @babel/runtime
@@ -165,6 +180,10 @@ ReactDOM.render(
   document.body
 )
 ```
+
+## Theming
+
+Phenotypes allows you to theme the css and component library to suit your needs. Please see the [theming docs](/THEMING.md) for more information on how to customize and theme phenotypes.
 
 [npm-url]: https://www.npmjs.com/package/@aminohealth/phenotypes
 [npm-version-image]: https://img.shields.io/npm/v/@aminohealth/phenotypes.svg?style=flat

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $grid-breakpoints: (
 
 The `_mixins.scss` file contains imports for functions and mixins that are used by other modules and components. Actual implementations should go in `styles/mixins`. E.g. `styles/mixins/_type.scss` contains both functions and mixins that help with typography.
 
-The `_theme_config.scss` file contains a css ruleset that defines the theming css variables that phenotypes uses. These are defined as css custom properties and allow custom themes for Phenotypes. Please see the [Theming guide](/guides/11-theming.md) for more info
+The `_theme_config.scss` file contains a CSS ruleset that defines the theming CSS variables that Phenotypes uses. These are defined as CSS custom properties and allow custom themes for Phenotypes. Please see the [Theming guide](/guides/11-theming.md) for more info.
 
 Phenotypes uses a slightly modified version of Bootstrap 4's reboot. [Read more about that.](https://v4-alpha.getbootstrap.com/content/reboot/)
 
@@ -150,13 +150,17 @@ $ npm install @aminohealth/phenotypes --save
 
 ### SASS
 
-The recommended way to use the styles for phenotypes is to import the scss entrypoint phenotypes.scss in your own project. When installed via npm this will be located at `@aminohealth/phenotypes/styles/phenotypes.scss`. This does require your project to use [Sass](https://sass-lang.com/). This is; however, not required and for that reason we also provide plain old css that you are able to use.
+The recommended way to use the styles for Phenotypes is to import the scss entrypoint phenotypes.scss in your own project. When installed via npm this will be located at `@aminohealth/phenotypes/styles/phenotypes.scss`. This does require your project to use [SASS](https://sass-lang.com/). This is; however, not required and for that reason we also provide plain old CSS that you are able to use.
 
-**NOTE**  By default the phenotypes.scss entry point when compiled will include CSS variables in the output. CSS variables are required for custom themes. CSS variables will work fine for all evergreen browsers; however, if you need to support a browser that does not support CSS variables (IE) or do not require a custom theme, you can compile the css variables away (Or see the [Theming guide](/guides/11-theming.md) for supporting IE .) CSS variables can be compiled away easily by post-processing via [postcss](https://postcss.org/) and using the [postcss-preset-env](https://preset-env.cssdb.org/) plugin. An example of how to do this is can be seen in our own build process when we compile the phenotypes.scss file to plain old css [here](./scripts/compileScss.js#L40-L48).
+**NOTE**  By default the phenotypes.scss entry point when compiled will include CSS variables in the output. CSS variables are required for custom themes. CSS variables will work fine for all evergreen browsers; however, if you need to support a browser that does not support CSS variables (IE) or do not require a custom theme, you can compile the CSS variables away (Or see the [Theming guide](/guides/11-theming.md) for supporting IE). CSS variables can be compiled away easily by post-processing via [postcss](https://postcss.org/) and using the [postcss-preset-env](https://preset-env.cssdb.org/) plugin. An example of how to do this is can be seen in our own build process when we compile the phenotypes.scss file to plain old CSS [here](./scripts/compileScss.js#L40-L48).
 
 ### CSS
 
-If you do not want to use sass there are two different css files that Phenotypes provides. The most straightforward of which is located at `@aminohealth/dist/css/phenotypes.css` when installed via npm. The other file is a themable css file that is located at `@aminohealth/dist/css/phenotypes.themable.css`. This file uses CSS variables to set theme variables and propagate those values to the Phenotypes styling. More information on this can be found in the [Theming guide](/guides/11-theming.md).
+If you do not want to use SASS there are two different CSS files that Phenotypes provides. The most straightforward of which is located at `@aminohealth/dist/css/phenotypes.css` when installed via npm. The other file is a themable CSS file that is located at `@aminohealth/dist/css/phenotypes.themable.css`. This file uses CSS variables to set theme variables and propagate those values to the Phenotypes styling. More information on this can be found in the [Theming guide](/guides/11-theming.md).
+
+## Browser Support
+
+CSS variables (used in theming) are [supported by all evergreen browsers](https://caniuse.com/#feat=css-variables). As with most modern web standards Internet Explorer is not supported by default. If you must support IE you can use the [css-vars-ponyfill](https://jhildenbiddle.github.io/css-vars-ponyfill/#/) that will compile away the CSS variables at runtime. This ponyfill will work for all browsers that do not support CSS variables not just IE.
 
 ### Peer Dependencies
 
@@ -183,7 +187,7 @@ ReactDOM.render(
 
 ## Theming
 
-Phenotypes allows you to theme the css and component library to suit your needs. Please see the [Theming guide](/guides/11-theming.md) for more information on how to customize and theme phenotypes.
+Phenotypes allows you to theme the CSS and component library to suit your needs. Please see the [Theming guide](/guides/11-theming.md) for more information on how to customize and theme Phenotypes.
 
 [npm-url]: https://www.npmjs.com/package/@aminohealth/phenotypes
 [npm-version-image]: https://img.shields.io/npm/v/@aminohealth/phenotypes.svg?style=flat

--- a/THEMING.md
+++ b/THEMING.md
@@ -1,0 +1,143 @@
+# Theming Phenotypes
+
+Phenotypes allows theming for certain aspects of the library. This is done via css custom properties that can be overridden by you as the consumer in your own application.
+
+## Browser Support
+
+CSS variables are [supported by all evergreen browsers](https://caniuse.com/#feat=css-variables). As with most modern web standards Internet Explorer is not supported by default. If you must support IE you can use the [css-vars-ponyfill](https://jhildenbiddle.github.io/css-vars-ponyfill/#/) that will compile away the CSS variables at runtime. This ponyfill will work for all browsers that do not support CSS variables not just IE.
+
+## Theming
+
+Phenotypes exposes a set of variables that will theme the library styles as well as the React components. These variables provide easy customization for commonly used values like colors for text and components. The variables that we expose and can be themed are below.
+
+**NOTE:**
+For a good chunk of variables there are two variable declarations, with values from one relying on the other. For example the `--focus-color` variable relies on the `--focus-color-rgb-values` variable. This is done to allow styling of elements that are tied to each other color wise but don't necessarily need to be defined twice. Phenotypes allows you to customize focus color, but that also means that the box-shadow that provides the focus color "glow", must also match that customized focus color. In order to ensure that you don't need to define two different variables (`--focus-color` & `--focus-shadow-color`) we expose a top level variable that defines the rgb values that should be used for both. So in this case changing `--focus-color-rgb-values` will apply the change to both the focus color as well as the box-shadow that is tied to that focus color. **It is for this reason that we recommend setting the rgb-values and allowing those values to update variables downstream.**
+
+```css
+:root {
+  --text-color-primary: rgba(0, 0, 0, 0.86);
+  --text-color-secondary: rgba(0, 0, 0, 0.54);
+  --text-color-hint: rgba(0, 0, 0, 0.41);
+  --text-color-primary-reversed: #fff;
+  --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
+  --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
+
+
+  --brand-color-primary-rgb-values: 133, 59, 148;
+  --brand-color-primary: rgb(var(--brand-color-primary-rgb-values));
+  --brand-color-accent-rgb-values: 252, 134, 38;
+  --brand-color-accent: rgb(var(--brand-color-accent-rgb-values));
+  --positive-color-rgb-values: 45, 207, 161;
+  --positive-color: rgb(var(--positive-color-rgb-values));
+  --negative-color-rgb-values: 240, 77, 93;
+  --negative-color: rgb(var(--negative-color-rgb-values));
+  --warning-color-rgb-values: 252, 134, 38;
+  --warning-color: rgb(var(--warning-color-rgb-values));
+  --interactive-color-rgb-values: 22, 184, 224;
+  --interactive-color: rgb(var(--interactive-color-rgb-values));
+  --error-color: var(--negative-color);
+
+
+  --link-color: var(--interactive-color);
+  --link-hover-color-rgb-values: 0, 138, 179;
+  --link-hover-color: rgb(var(--link-hover-color-rgb-values));
+  --link-color-reversed-rgb-values: 127, 234, 255;
+  --link-color-reversed: rgb(var(--link-color-reversed-rgb-values));
+  --step-progress-active-color-rgb-values: 179, 93, 186;
+  --step-progress-active-color: rgb(
+    var(--step-progress-active-color-rgb-values)
+  );
+  --focus-color-rgb-values: 127, 234, 255;
+  --focus-color: rgb(var(--focus-color-rgb-values));
+  --widget-on-color: var(--positive-color);
+
+
+  --message-success-bg-color-rgb-values: 3, 171, 140;
+  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
+  --message-info-bg-color: var(--brand-color-primary);
+  --message-danger-bg-color: var(--error-color);
+
+
+  --danger-button-color: var(--negative-color);
+  --danger-button-focus-color: #ee3548;
+  --danger-button-active-color: #ec192e;
+
+
+  --primary-button-color: var(--interactive-color);
+  --primary-button-focus-color: #14a5c9;
+  --primary-button-active-color: #118ead;
+}
+```
+
+When overriding a variable you must define the `:root` rule. An example of setting an override is shown below:
+
+```css
+:root {
+    --focus-color-rgb-values: 0, 128, 0
+}
+```
+
+This will change both the focus color to green as well as apply the correct changes to the box-shadow that is tied to the focus color.
+
+**It is important to remember that CSS variables follow normal CSS cascade rules, so whichever root variable declaration comes last is the one that will be applied.**
+
+
+### Theming with SASS
+
+Theming with SASS is not any different than theming with plain css. When using SASS Phenotypes does provide you with some quality of life utilities to make theming these values easier. Phenotypes provides you with a sass `extract-rgb` function that makes it very easy to set the rgb-values variables. Ex:
+
+```scss
+// when overriding the rgb variable values for your own custom theme
+// you will need to set it to a triplet of numbers that correspond to rgb
+// values like so:
+
+:root {
+    --focus-color-rgb-values: 0, 128, 0
+}
+
+// When using sass, Phenotypes also provides a helper function that makes working
+// with exisiting colors easier.
+$green: #008000
+:root {
+    --focus-color-rgb-values: #{extract-rgb($green)};
+}
+
+// Using the `extract-rgb` helper is the equivalent of setting the
+// triplet of numbers directly.
+// The `extract-rgb` helper can also handle any type of color definition:
+:root {
+    // all of the following are equivalent
+    --focus-color-rgb-values: 0, 128, 0
+    --focus-color-rgb-values: #{extract-rgb(#008000)};
+    --focus-color-rgb-values: #{extract-rgb($green)};
+    --focus-color-rgb-values: #{extract-rgb(rgb(0, 128, 0))};
+    --focus-color-rgb-values: #{extract-rgb(hsl(120, 100, 25))};
+}
+```
+
+Phenotypes also provides you with a mixin called `color-variable` to easily author those pairs of CSS variables similar to what we have defined. Ex:
+
+```scss
+// If you are authoring a component that has a multiple elements to it
+// that you would like to be themable you can use the `color-variable` mixin
+
+:root {
+    @include color-variable(--primary-button-color, #008000);
+    // this mixin above will be compiled to the following css:
+    --primary-button-color-rgb-values: 0, 128, 0;
+    --primary-button-color: rgb(var(--primary-button-color-rgb-values));
+}
+
+// these compiled variables can then be used throughout the application
+// wherever they are needed. When the rgb values are overridden, all of the
+// places where the variables are used will be updated.
+
+.PrimaryButton {
+    background-color: var(--primary-button-color);
+}
+
+.PrimaryButton:hover {
+    background-color: rgba(var(--primary-button-color-rgb-values), .5);
+}
+
+```

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -86,7 +86,7 @@
   --primary-button-color: var(--interactive-color);
   --link-color: var(--interactive-color);
   --link-color-reversed: #7feaff;
-  --focus-color:blue-100; }
+  --focus-color: #7feaff; }
 
 html {
   box-sizing: border-box;
@@ -1205,7 +1205,7 @@ hr {
   top: -10px;
   width: 24px; }
   .Slider__handle::after {
-    background-color: #7feaff;
+    background-color: var(--focus-color);
     border-radius: 50%;
     bottom: 7px;
     box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
@@ -1228,7 +1228,7 @@ hr {
   background-color: rgba(0, 0, 0, 0.14); }
 
 .Slider__fill {
-  background-color: #2dcfa1; }
+  background-color: var(--widget-on-color); }
 
 .Slider__handle {
   background-color: #fff; }

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -1309,7 +1309,7 @@ hr {
     opacity: 1; }
 
 .TextInput:focus {
-  border-color: #7feaff;
+  border-color: var(--focus-color);
   box-shadow: 0 0 11px rgba(127, 234, 255, 0.41);
   outline: 0; }
 
@@ -1323,7 +1323,7 @@ hr {
 
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
-  border-color: #f04d5d; }
+  border-color: var(--error-color); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
     box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
@@ -1411,7 +1411,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: #f04d5d;
+  color: var(--error-color);
   margin-top: 7px; }
   .FormGroup__error::before {
     content: '✘ ';
@@ -1450,7 +1450,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: #f04d5d;
+  color: var(--error-color);
   margin-top: 7px; }
   .FormGroup--medium .FormGroup__error::before {
     content: '✘ ';
@@ -1505,7 +1505,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-sm .FormGroup__error::before {
       content: '✘ ';
@@ -1556,7 +1556,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-md .FormGroup__error::before {
       content: '✘ ';
@@ -1607,7 +1607,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-lg .FormGroup__error::before {
       content: '✘ ';
@@ -1658,7 +1658,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-xl .FormGroup__error::before {
       content: '✘ ';

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -71,22 +71,26 @@
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
   --brand-color-primary: #853b94;
-  --message-info-bg-color: var(--brand-color-primary);
-  --step-progress-active-color: #b35dba;
   --brand-color-accent: #fc8626;
   --positive-color: #2dcfa1;
-  --widget-on-color: var(--positive-color);
-  --message-success-bg-color: #03ab8c;
   --negative-color: #f04d5d;
-  --error-color: var(--negative-color);
-  --message-danger-bg-color: var(--error-color);
-  --danger-button-color: var(--negative-color);
   --warning-color: #fc8626;
+  --error-color: var(--negative-color);
   --interactive-color: #16b8e0;
-  --primary-button-color: var(--interactive-color);
+  --step-progress-active-color: #b35dba;
+  --widget-on-color: var(--positive-color);
+  --focus-color: #7feaff;
   --link-color: var(--interactive-color);
   --link-color-reversed: #7feaff;
-  --focus-color: #7feaff; }
+  --message-success-bg-color: #03ab8c;
+  --message-info-bg-color: var(--brand-color-primary);
+  --message-danger-bg-color: var(--error-color);
+  --danger-button-color: var(--negative-color);
+  --danger-button-focus-color: #ee3548;
+  --danger-button-active-color: #ec192e;
+  --primary-button-color: var(--interactive-color);
+  --primary-button-focus-color: #14a5c9;
+  --primary-button-active-color: #118ead; }
 
 html {
   box-sizing: border-box;
@@ -455,31 +459,31 @@ hr {
   cursor: not-allowed; }
 
 .Button--danger .Button__control {
-  background: #f04d5d;
+  background: var(--danger-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
-    background: #ee3548;
+    background: var(--danger-button-focus-color);
     color: #fff; }
 
 .Button--danger .Button__control:active,
 .Button--danger.Button--is-active .Button__control {
-  background: #ec192e; }
+  background: var(--danger-button-active-color); }
 
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
-  background: #16b8e0;
+  background: var(--primary-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
-    background: #14a5c9;
+    background: var(--primary-button-focus-color);
     color: #fff; }
 
 .Button--primary .Button__control:active,
 .Button--primary.Button--is-active .Button__control {
   box-shadow: none;
-  background: #118ead; }
+  background: var(--primary-button-active-color); }
 
 .Button--link .Button__control .Button__control {
   background: transparent;

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -70,31 +70,31 @@
   --text-color-primary-reversed: #fff;
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
-  --brand-color-primary-rgb: 133, 59, 148;
-  --brand-color-primary: rgb(var(--brand-color-primary-rgb));
-  --brand-color-accent-rgb: 252, 134, 38;
-  --brand-color-accent: rgb(var(--brand-color-accent-rgb));
-  --positive-color-rgb: 45, 207, 161;
-  --positive-color: rgb(var(--positive-color-rgb));
-  --negative-color-rgb: 240, 77, 93;
-  --negative-color: rgb(var(--negative-color-rgb));
-  --warning-color-rgb: 252, 134, 38;
-  --warning-color: rgb(var(--warning-color-rgb));
-  --interactive-color-rgb: 22, 184, 224;
-  --interactive-color: rgb(var(--interactive-color-rgb));
+  --brand-color-primary-rgb-values: 133, 59, 148;
+  --brand-color-primary: rgb(var(--brand-color-primary-rgb-values));
+  --brand-color-accent-rgb-values: 252, 134, 38;
+  --brand-color-accent: rgb(var(--brand-color-accent-rgb-values));
+  --positive-color-rgb-values: 45, 207, 161;
+  --positive-color: rgb(var(--positive-color-rgb-values));
+  --negative-color-rgb-values: 240, 77, 93;
+  --negative-color: rgb(var(--negative-color-rgb-values));
+  --warning-color-rgb-values: 252, 134, 38;
+  --warning-color: rgb(var(--warning-color-rgb-values));
+  --interactive-color-rgb-values: 22, 184, 224;
+  --interactive-color: rgb(var(--interactive-color-rgb-values));
   --error-color: var(--negative-color);
   --link-color: var(--interactive-color);
-  --link-hover-color-rgb: 0, 138, 179;
-  --link-hover-color: rgb(var(--link-hover-color-rgb));
-  --link-color-reversed-rgb: 127, 234, 255;
-  --link-color-reversed: rgb(var(--link-color-reversed-rgb));
-  --step-progress-active-color-rgb: 179, 93, 186;
-  --step-progress-active-color: rgb(var(--step-progress-active-color-rgb));
-  --focus-color-rgb: 127, 234, 255;
-  --focus-color: rgb(var(--focus-color-rgb));
+  --link-hover-color-rgb-values: 0, 138, 179;
+  --link-hover-color: rgb(var(--link-hover-color-rgb-values));
+  --link-color-reversed-rgb-values: 127, 234, 255;
+  --link-color-reversed: rgb(var(--link-color-reversed-rgb-values));
+  --step-progress-active-color-rgb-values: 179, 93, 186;
+  --step-progress-active-color: rgb(var(--step-progress-active-color-rgb-values));
+  --focus-color-rgb-values: 127, 234, 255;
+  --focus-color: rgb(var(--focus-color-rgb-values));
   --widget-on-color: var(--positive-color);
-  --message-success-bg-color-rgb: 3, 171, 140;
-  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb));
+  --message-success-bg-color-rgb-values: 3, 171, 140;
+  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);
   --danger-button-color: var(--negative-color);
@@ -600,7 +600,7 @@ hr {
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -610,7 +610,7 @@ hr {
     border-color: #232323; }
   .Checkbox__input:checked:focus ~ .Checkbox__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
   .Checkbox__input:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
     background-color: #232323;
@@ -871,7 +871,7 @@ hr {
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -883,7 +883,7 @@ hr {
       display: block; }
   .Radio__input:checked:focus ~ .Radio__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
   .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
     background-color: #232323;
     border-color: #232323; }
@@ -1173,7 +1173,7 @@ hr {
     margin-right: 0; }
   .ProgressBar__step::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb), 0.54);
+    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb-values), 0.54);
     content: " ";
     height: 100%;
     opacity: 0;
@@ -1279,7 +1279,7 @@ hr {
   .Switch__toggler::after {
     background-color: var(--focus-color);
     border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb), 0.7);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), 0.7);
     content: ' ';
     left: 50%;
     opacity: 0;
@@ -1326,7 +1326,7 @@ hr {
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41);
   outline: 0; }
 
 .TextInput:disabled,
@@ -1342,7 +1342,7 @@ hr {
   border-color: var(--error-color); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
-    box-shadow: 0 0 11px rgba(var(--negative-color-rgb), 0.54); }
+    box-shadow: 0 0 11px rgba(var(--negative-color-rgb-values), 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -63,6 +63,34 @@
   src: url("webfonts/33AD5D_3_0.eot");
   src: url("webfonts/33AD5D_3_0.eot?#iefix") format("embedded-opentype"), url("webfonts/33AD5D_3_0.woff2") format("woff2"), url("webfonts/33AD5D_3_0.woff") format("woff"), url("webfonts/33AD5D_3_0.ttf") format("truetype"); }
 
+:root {
+  --text-color-primary: $text-color-primary;
+  --text-color-secondary: $text-color-secondary;
+  --text-color-hint: $text-color-hint;
+  --text-color-primary-reversed: $text-color-primary-reversed;
+  --text-color-secondary-reversed: $text-color-secondary-reversed;
+  --text-color-hint-reversed: $text-color-hint-reversed;
+  --brand-color-primary: #853b94;
+  --brand-color-accent-1: #58166e;
+  --data-color: #2dcfa1;
+  --data-color-reversed: #89f0cf;
+  --positive-color: #2dcfa1;
+  --widget-on-color: var(--positive-color);
+  --toast-success-bg-color: var(--positive-color);
+  --negative-color: #f04d5d;
+  --toast-error-bg-color: var(--negative-color);
+  --warning-color: #fc8626;
+  --interactive-color: #16b8e0;
+  --toast-info-bg-color: var(--interactive-color);
+  --primary-button-color: var(--interactive-color);
+  --link-color: var(--interactive-color);
+  --bg-color-light: #f9f9f9;
+  --bg-color-dark: #232323;
+  --link-color-reversed: #7feaff;
+  --focus-color:blue-100;
+  --typeahead-selection-color:
+; }
+
 html {
   box-sizing: border-box;
   font-family: sans-serif;
@@ -110,8 +138,7 @@ p {
 abbr[title],
 abbr[data-original-title] {
   text-decoration: underline;
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   cursor: help;
   border-bottom: 0; }
 
@@ -593,10 +620,7 @@ hr {
   left: 0;
   pointer-events: none;
   position: absolute;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none; }
+  user-select: none; }
 
 .Checkbox--is-disabled {
   cursor: not-allowed; }
@@ -869,10 +893,7 @@ hr {
   left: 0;
   pointer-events: none;
   position: absolute;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none; }
+  user-select: none; }
   .Radio__indicator::after {
     background-color: #fff;
     border-radius: 50%;
@@ -1286,15 +1307,6 @@ hr {
   color: rgba(0, 0, 0, 0.86);
   line-height: 1.49271;
   width: 100%; }
-  .TextInput::-moz-placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
-  .TextInput:-ms-input-placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
-  .TextInput::-ms-input-placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
   .TextInput::placeholder {
     color: rgba(0, 0, 0, 0.41);
     opacity: 1; }

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -70,20 +70,31 @@
   --text-color-primary-reversed: #fff;
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
-  --brand-color-primary: #853b94;
-  --brand-color-accent: #fc8626;
-  --positive-color: #2dcfa1;
-  --negative-color: #f04d5d;
-  --warning-color: #fc8626;
+  --brand-color-primary-rgb: 133, 59, 148;
+  --brand-color-primary: rgb(var(--brand-color-primary-rgb));
+  --brand-color-accent-rgb: 252, 134, 38;
+  --brand-color-accent: rgb(var(--brand-color-accent-rgb));
+  --positive-color-rgb: 45, 207, 161;
+  --positive-color: rgb(var(--positive-color-rgb));
+  --negative-color-rgb: 240, 77, 93;
+  --negative-color: rgb(var(--negative-color-rgb));
+  --warning-color-rgb: 252, 134, 38;
+  --warning-color: rgb(var(--warning-color-rgb));
+  --interactive-color-rgb: 22, 184, 224;
+  --interactive-color: rgb(var(--interactive-color-rgb));
   --error-color: var(--negative-color);
-  --interactive-color: #16b8e0;
-  --step-progress-active-color: #b35dba;
-  --widget-on-color: var(--positive-color);
-  --focus-color: #7feaff;
   --link-color: var(--interactive-color);
-  --link-hover-color: #008ab3;
-  --link-color-reversed: #7feaff;
-  --message-success-bg-color: #03ab8c;
+  --link-hover-color-rgb: 0, 138, 179;
+  --link-hover-color: rgb(var(--link-hover-color-rgb));
+  --link-color-reversed-rgb: 127, 234, 255;
+  --link-color-reversed: rgb(var(--link-color-reversed-rgb));
+  --step-progress-active-color-rgb: 179, 93, 186;
+  --step-progress-active-color: rgb(var(--step-progress-active-color-rgb));
+  --focus-color-rgb: 127, 234, 255;
+  --focus-color: rgb(var(--focus-color-rgb));
+  --widget-on-color: var(--positive-color);
+  --message-success-bg-color-rgb: 3, 171, 140;
+  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb));
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);
   --danger-button-color: var(--negative-color);
@@ -589,7 +600,7 @@ hr {
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -599,7 +610,7 @@ hr {
     border-color: #232323; }
   .Checkbox__input:checked:focus ~ .Checkbox__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
   .Checkbox__input:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
     background-color: #232323;
@@ -860,7 +871,7 @@ hr {
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -872,7 +883,7 @@ hr {
       display: block; }
   .Radio__input:checked:focus ~ .Radio__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
   .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
     background-color: #232323;
     border-color: #232323; }
@@ -1162,11 +1173,11 @@ hr {
     margin-right: 0; }
   .ProgressBar__step::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 7px 0 #e39ae3;
-    content: ' ';
+    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb), 0.54);
+    content: " ";
     height: 100%;
     opacity: 0;
-    transition: opacity .2s linear;
+    transition: opacity 0.2s linear;
     width: 100%; }
 
 .ProgressBar__step--active::after {
@@ -1266,9 +1277,9 @@ hr {
   top: 2px;
   transition: right .15s ease-out; }
   .Switch__toggler::after {
-    background-color: #7feaff;
+    background-color: var(--focus-color);
     border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb), 0.7);
     content: ' ';
     left: 50%;
     opacity: 0;
@@ -1315,7 +1326,7 @@ hr {
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41);
   outline: 0; }
 
 .TextInput:disabled,
@@ -1331,7 +1342,7 @@ hr {
   border-color: var(--error-color); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
-    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+    box-shadow: 0 0 11px rgba(var(--negative-color-rgb), 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -1282,7 +1282,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Switch__input:checked ~ .Switch__indicator {
-    background-color: #2dcfa1; }
+    background-color: var(--widget-on-color); }
     .Switch__input:checked ~ .Switch__indicator .Switch__toggler {
       right: 2px; }
   .Switch__input:disabled ~ .Switch__indicator {

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -819,15 +819,15 @@ hr {
   padding: 16px; }
 
 .Message--success {
-  background-color: #03ab8c;
+  background-color: var(--message-success-bg-color);
   color: #fff; }
 
 .Message--info {
-  background-color: #853b94;
+  background-color: var(--message-info-bg-color);
   color: #fff; }
 
 .Message--danger {
-  background-color: #f04d5d;
+  background-color: var(--message-danger-bg-color);
   color: #fff; }
 
 .Radio {

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -1305,7 +1305,7 @@ hr {
   line-height: 1.49271;
   width: 100%; }
   .TextInput::placeholder {
-    color: rgba(0, 0, 0, 0.41);
+    color: var(--text-color-hint);
     opacity: 1; }
 
 .TextInput:focus {
@@ -1317,7 +1317,7 @@ hr {
 .TextInput[readonly] {
   background: #eee;
   border-color: #eee;
-  color: rgba(0, 0, 0, 0.41);
+  color: var(--text-color-hint);
   cursor: not-allowed;
   opacity: 1; }
 
@@ -5999,7 +5999,7 @@ hr {
   color: var(--text-color-secondary) !important; }
 
 .text-color-hint {
-  color: rgba(0, 0, 0, 0.41) !important; }
+  color: var(--text-color-hint) !important; }
 
 .text-color-reversed-primary {
   color: #fff !important; }

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -81,6 +81,7 @@
   --widget-on-color: var(--positive-color);
   --focus-color: #7feaff;
   --link-color: var(--interactive-color);
+  --link-hover-color: #008ab3;
   --link-color-reversed: #7feaff;
   --message-success-bg-color: #03ab8c;
   --message-info-bg-color: var(--brand-color-primary);
@@ -194,12 +195,12 @@ sup {
   top: -.5em; }
 
 a {
-  color: #16b8e0;
+  color: var(--link-color);
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
   a:hover {
-    color: #008ab3;
+    color: var(--link-hover-color);
     text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -1156,7 +1156,7 @@ hr {
   .ProgressBar__step:last-child {
     margin-right: 0; }
   .ProgressBar__step::after {
-    background-color: #b35dba;
+    background-color: var(--step-progress-active-color);
     box-shadow: 0 0 7px 0 #e39ae3;
     content: ' ';
     height: 100%;

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -6002,13 +6002,13 @@ hr {
   color: var(--text-color-hint) !important; }
 
 .text-color-reversed-primary {
-  color: #fff !important; }
+  color: var(--text-color-primary-reversed) !important; }
 
 .text-color-reversed-secondary {
-  color: rgba(255, 255, 255, 0.76) !important; }
+  color: var(--text-color-secondary-reversed) !important; }
 
 .text-color-reversed-hint {
-  color: rgba(255, 255, 255, 0.59) !important; }
+  color: var(--text-color-hint-reversed) !important; }
 
 .text-color-orange {
   color: #fc8626 !important; }

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -410,7 +410,7 @@ hr {
   background: rgba(0, 0, 0, 0.07);
   border: 0;
   border-radius: 3px;
-  color: rgba(0, 0, 0, 0.86);
+  color: var(--text-color-primary);
   cursor: pointer;
   display: inline-block;
   font-weight: normal;
@@ -429,7 +429,7 @@ hr {
 .Button__control:focus {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   background: rgba(0, 0, 0, 0.12);
-  color: rgba(0, 0, 0, 0.86);
+  color: var(--text-color-primary);
   text-decoration: none;
   transform: translateY(-2.25px) scaleX(1.015) scaleY(1.015);
   transition-duration: .08s; }
@@ -1301,7 +1301,7 @@ hr {
   -webkit-appearance: none;
   border: 2px solid #dbdbdb;
   border-radius: 3px;
-  color: rgba(0, 0, 0, 0.86);
+  color: var(--text-color-primary);
   line-height: 1.49271;
   width: 100%; }
   .TextInput::placeholder {
@@ -5993,7 +5993,7 @@ hr {
   color: inherit !important; }
 
 .text-color-primary {
-  color: rgba(0, 0, 0, 0.86) !important; }
+  color: var(--text-color-primary) !important; }
 
 .text-color-secondary {
   color: rgba(0, 0, 0, 0.54) !important; }

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -64,32 +64,29 @@
   src: url("webfonts/33AD5D_3_0.eot?#iefix") format("embedded-opentype"), url("webfonts/33AD5D_3_0.woff2") format("woff2"), url("webfonts/33AD5D_3_0.woff") format("woff"), url("webfonts/33AD5D_3_0.ttf") format("truetype"); }
 
 :root {
-  --text-color-primary: $text-color-primary;
-  --text-color-secondary: $text-color-secondary;
-  --text-color-hint: $text-color-hint;
-  --text-color-primary-reversed: $text-color-primary-reversed;
-  --text-color-secondary-reversed: $text-color-secondary-reversed;
-  --text-color-hint-reversed: $text-color-hint-reversed;
+  --text-color-primary: rgba(0, 0, 0, 0.86);
+  --text-color-secondary: rgba(0, 0, 0, 0.54);
+  --text-color-hint: rgba(0, 0, 0, 0.41);
+  --text-color-primary-reversed: #fff;
+  --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
+  --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
   --brand-color-primary: #853b94;
-  --brand-color-accent-1: #58166e;
-  --data-color: #2dcfa1;
-  --data-color-reversed: #89f0cf;
+  --message-info-bg-color: var(--brand-color-primary);
+  --step-progress-active-color: #b35dba;
+  --brand-color-accent: #fc8626;
   --positive-color: #2dcfa1;
   --widget-on-color: var(--positive-color);
-  --toast-success-bg-color: var(--positive-color);
+  --message-success-bg-color: #03ab8c;
   --negative-color: #f04d5d;
-  --toast-error-bg-color: var(--negative-color);
+  --error-color: var(--negative-color);
+  --message-danger-bg-color: var(--error-color);
+  --danger-button-color: var(--negative-color);
   --warning-color: #fc8626;
   --interactive-color: #16b8e0;
-  --toast-info-bg-color: var(--interactive-color);
   --primary-button-color: var(--interactive-color);
   --link-color: var(--interactive-color);
-  --bg-color-light: #f9f9f9;
-  --bg-color-dark: #232323;
   --link-color-reversed: #7feaff;
-  --focus-color:blue-100;
-  --typeahead-selection-color:
-; }
+  --focus-color:blue-100; }
 
 html {
   box-sizing: border-box;

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -6026,6 +6026,27 @@ hr {
 .text-color-reversed-hint {
   color: var(--text-color-hint-reversed) !important; }
 
+.text-color-brand-primary {
+  color: var(--brand-color-primary) !important; }
+
+.text-color-brand-accent {
+  color: var(--brand-color-accent) !important; }
+
+.text-color-positive {
+  color: var(--positive-color) !important; }
+
+.text-color-negative {
+  color: var(--negative-color) !important; }
+
+.text-color-warning {
+  color: var(--warning-color) !important; }
+
+.text-color-interactive {
+  color: var(--interactive-color) !important; }
+
+.text-color-error {
+  color: var(--error-color) !important; }
+
 .text-color-orange {
   color: #fc8626 !important; }
 

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -607,7 +607,7 @@ hr {
   .Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
   .Checkbox__input:disabled ~ .Checkbox__label {
-    color: rgba(0, 0, 0, 0.54); }
+    color: var(--text-color-secondary); }
 
 .Checkbox__indicator {
   background-color: #fff;
@@ -881,7 +881,7 @@ hr {
   .Radio__input:disabled:checked:active ~ .Radio__indicator::after {
     background-color: #c1c1c1; }
   .Radio__input:disabled ~ .Radio__label {
-    color: rgba(0, 0, 0, 0.54); }
+    color: var(--text-color-secondary); }
 
 .Radio__indicator {
   background-color: #fff;
@@ -1422,7 +1422,7 @@ hr {
   line-height: 18px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--text-color-secondary);
   margin-top: 7px; }
 
 .FormGroup--small .FormGroup__label {
@@ -1461,7 +1461,7 @@ hr {
   line-height: 18px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--text-color-secondary);
   margin-top: 7px; }
 
 .FormGroup--large .FormGroup__label {
@@ -1515,7 +1515,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-sm .FormGroup__label {
     font-size: 18px;
@@ -1566,7 +1566,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-md .FormGroup__label {
     font-size: 18px;
@@ -1617,7 +1617,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-lg .FormGroup__label {
     font-size: 18px;
@@ -1668,7 +1668,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-xl .FormGroup__label {
     font-size: 18px;
@@ -5996,7 +5996,7 @@ hr {
   color: var(--text-color-primary) !important; }
 
 .text-color-secondary {
-  color: rgba(0, 0, 0, 0.54) !important; }
+  color: var(--text-color-secondary) !important; }
 
 .text-color-hint {
   color: rgba(0, 0, 0, 0.41) !important; }

--- a/guides/06-spacing.md
+++ b/guides/06-spacing.md
@@ -32,7 +32,7 @@ Phenotypes aims to balance simplicity and flexibility, but no spacing system can
 
 ## Appendix
 
-| Sass variable | Space |
+| SASS variable | Space |
 | -------- | ----- |
 | `$spacer-0` | 0 |
 | `$spacer-1` | 5px |

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -87,7 +87,7 @@ This will change both the focus color to green as well as apply the correct chan
 
 ### Theming with SASS
 
-Theming with SASS is not any different than theming with plain css. When using SASS Phenotypes does provide you with some quality of life utilities to make theming these values easier. Phenotypes provides you with a sass `extract-rgb` function that makes it very easy to set the rgb-values variables. Ex:
+Theming with SASS is not any different than theming with plain css. When using SASS Phenotypes does provide you with some quality of life utilities to make theming these values easier. Phenotypes provides you with a SASS `extract-rgb` function that makes it very easy to set the rgb-values variables. Ex:
 
 ```scss
 // when overriding the rgb variable values for your own custom theme
@@ -98,7 +98,7 @@ Theming with SASS is not any different than theming with plain css. When using S
     --focus-color-rgb-values: 0, 128, 0;
 }
 
-// When using sass, Phenotypes also provides a helper function that makes working
+// When using SASS, Phenotypes also provides a helper function that makes working
 // with exisiting colors easier.
 $green: #008000
 :root {
@@ -126,7 +126,7 @@ Phenotypes also provides you with a mixin called `color-variable` to easily auth
 
 :root {
     @include color-variable(--primary-button-color, #008000);
-    // this mixin above will be compiled to the following css:
+    // this mixin above will be compiled to the following CSS:
     --primary-button-color-rgb-values: 0, 128, 0;
     --primary-button-color: rgb(var(--primary-button-color-rgb-values));
 }

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -3,8 +3,6 @@ title: Theming
 status: draft
 ---
 
-# Theming Phenotypes
-
 Phenotypes allows theming for certain aspects of the library. This is done via css custom properties that can be overridden by you as the consumer in your own application.
 
 ## Browser Support

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -1,3 +1,8 @@
+---
+title: Theming
+status: draft
+---
+
 # Theming Phenotypes
 
 Phenotypes allows theming for certain aspects of the library. This is done via css custom properties that can be overridden by you as the consumer in your own application.

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -9,7 +9,7 @@ Phenotypes allows theming for certain aspects of the library. This is done via c
 
 CSS variables are [supported by all evergreen browsers](https://caniuse.com/#feat=css-variables). As with most modern web standards Internet Explorer is not supported by default. If you must support IE you can use the [css-vars-ponyfill](https://jhildenbiddle.github.io/css-vars-ponyfill/#/) that will compile away the CSS variables at runtime. This ponyfill will work for all browsers that do not support CSS variables not just IE.
 
-## Theming
+## Custom Themes and CSS Variables
 
 Phenotypes exposes a set of variables that will theme the library styles as well as the React components. These variables provide easy customization for commonly used values like colors for text and components. The variables that we expose and can be themed are below.
 
@@ -95,7 +95,7 @@ Theming with SASS is not any different than theming with plain css. When using S
 // values like so:
 
 :root {
-    --focus-color-rgb-values: 0, 128, 0
+    --focus-color-rgb-values: 0, 128, 0;
 }
 
 // When using sass, Phenotypes also provides a helper function that makes working
@@ -110,7 +110,7 @@ $green: #008000
 // The `extract-rgb` helper can also handle any type of color definition:
 :root {
     // all of the following are equivalent
-    --focus-color-rgb-values: 0, 128, 0
+    --focus-color-rgb-values: 0, 128, 0;
     --focus-color-rgb-values: #{extract-rgb(#008000)};
     --focus-color-rgb-values: #{extract-rgb($green)};
     --focus-color-rgb-values: #{extract-rgb(rgb(0, 128, 0))};

--- a/library/_preview.jsx
+++ b/library/_preview.jsx
@@ -90,7 +90,7 @@ class Preview extends React.Component {
     return (
       <div id="phenotypes__fractalPreview">
         <link media="all" rel="stylesheet" href="/css/preview.css" />
-        <link media="all" rel="stylesheet" href="/css/phenotypes.css" />
+        <link media="all" rel="stylesheet" href="/css/phenotypes.themable.css" />
 
         {this.variants.map(variant => {
           const rootElementId = ROOT_ELEMENT_ID_PREFIX + variant.handle;

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -91,20 +91,20 @@
 
 .Button--danger {
   .Button__control {
-    background: $red;
+    background: var(--danger-button-color);
     color: $white;
     font-weight: $font-weight-bold;
 
     &:hover,
     &:focus {
-      background: darken($red, 5);
+      background: var(--danger-button-focus-color);
       color: $white;
     }
   }
 
   .Button__control:active,
   &.Button--is-active .Button__control {
-    background: darken($red, 11);
+    background: var(--danger-button-active-color);
   }
 }
 
@@ -114,14 +114,14 @@
 .Button--primary {
   .Button__control {
     @include depth(4);
-    background: $blue;
+    background: var(--primary-button-color);
     color: $white;
     font-weight: $font-weight-bold;
 
     &:hover,
     &:focus {
       @include depth(7);
-      background: darken($blue, 5);
+      background: var(--primary-button-focus-color);
       color: $white;
     }
   }
@@ -129,7 +129,7 @@
   .Button__control:active,
   &.Button--is-active .Button__control {
     @include depth(0);
-    background: darken($blue, 11);
+    background: var(--primary-button-active-color);
   }
 }
 

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -32,7 +32,7 @@
   background: rgba($black, $alpha-200);
   border: 0;
   border-radius: $border-radius;
-  color: $text-color-primary;
+  color: var(--text-color-primary);
   cursor: pointer;
   display: inline-block;
   font-weight: $font-weight-normal;
@@ -55,7 +55,7 @@
 .Button__control:focus {
   @include depth(4);
   background: rgba($black, $alpha-200 + .05);
-  color: $text-color-primary;
+  color: var(--text-color-primary);
   text-decoration: none;
   transform: translateY(-2.25px) scaleX(1.015) scaleY(1.015);
   transition-duration: .08s;

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -70,7 +70,7 @@
 
   &:focus ~ .Checkbox__indicator {
     border-color: $blue-100;
-    box-shadow: 0 0 11px rgba($blue-100, $alpha-500);
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), $alpha-500);
   }
 
   &:active ~ .Checkbox__indicator {
@@ -86,7 +86,7 @@
 
   &:checked:focus ~ .Checkbox__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba($blue-200, $alpha-400);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), $alpha-400);
   }
 
   &:checked:active ~ .Checkbox__indicator {

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -108,7 +108,7 @@
   }
 
   &:disabled ~ .Checkbox__label {
-    color: $text-color-secondary;
+    color: var(--text-color-secondary);
   }
 }
 

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -70,7 +70,7 @@
 
   &:focus ~ .Checkbox__indicator {
     border-color: $blue-100;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), $alpha-500);
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), $alpha-500);
   }
 
   &:active ~ .Checkbox__indicator {
@@ -86,7 +86,7 @@
 
   &:checked:focus ~ .Checkbox__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), $alpha-400);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), $alpha-400);
   }
 
   &:checked:active ~ .Checkbox__indicator {

--- a/library/components/form_group/_form_group.scss
+++ b/library/components/form_group/_form_group.scss
@@ -30,7 +30,7 @@
 
     .FormGroup__hint {
       @include text-1;
-      color: $text-color-secondary;
+      color: var(--text-color-secondary);
       margin-top: $spacer-2;
     }
   }

--- a/library/components/form_group/_form_group.scss
+++ b/library/components/form_group/_form_group.scss
@@ -19,7 +19,7 @@
 
     .FormGroup__error {
       @include text-2;
-      color: $brand-danger;
+      color: var(--error-color);
       margin-top: $spacer-2;
 
       &::before {

--- a/library/components/message/_message.scss
+++ b/library/components/message/_message.scss
@@ -7,16 +7,16 @@
 }
 
 .Message--success {
-  background-color: $brand-success;
+  background-color: var(--message-success-bg-color);
   color: $white;
 }
 
 .Message--info {
-  background-color: $brand-primary;
+  background-color: var(--message-info-bg-color);
   color: $white;
 }
 
 .Message--danger {
-  background-color: $brand-danger;
+  background-color: var(--message-danger-bg-color);
   color: $white;
 }

--- a/library/components/progress_bar/_progress_bar.scss
+++ b/library/components/progress_bar/_progress_bar.scss
@@ -24,11 +24,12 @@
 
   &::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 modular-scale-px(-6) 0 $purple-100;
-    content: ' ';
+    box-shadow: 0 0 modular-scale-px(-6) 0
+      rgba(var(--step-progress-active-color-rgb), $alpha-600);
+    content: " ";
     height: 100%;
     opacity: 0;
-    transition: opacity .2s linear;
+    transition: opacity 0.2s linear;
     width: 100%;
   }
 }

--- a/library/components/progress_bar/_progress_bar.scss
+++ b/library/components/progress_bar/_progress_bar.scss
@@ -25,7 +25,7 @@
   &::after {
     background-color: var(--step-progress-active-color);
     box-shadow: 0 0 modular-scale-px(-6) 0
-      rgba(var(--step-progress-active-color-rgb), $alpha-600);
+      rgba(var(--step-progress-active-color-rgb-values), $alpha-600);
     content: " ";
     height: 100%;
     opacity: 0;

--- a/library/components/progress_bar/_progress_bar.scss
+++ b/library/components/progress_bar/_progress_bar.scss
@@ -23,7 +23,7 @@
   }
 
   &::after {
-    background-color: $purple-200;
+    background-color: var(--step-progress-active-color);
     box-shadow: 0 0 modular-scale-px(-6) 0 $purple-100;
     content: ' ';
     height: 100%;

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -123,7 +123,7 @@
   }
 
   &:disabled ~ .Radio__label {
-    color: $text-color-secondary;
+    color: var(--text-color-secondary);
   }
 }
 

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -75,7 +75,7 @@
 
   &:focus ~ .Radio__indicator {
     border-color: $blue-100;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), $alpha-500);
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), $alpha-500);
   }
 
   &:active ~ .Radio__indicator {
@@ -96,7 +96,7 @@
 
   &:checked:focus ~ .Radio__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), $alpha-400);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), $alpha-400);
   }
 
   &:checked:active:not(:disabled) ~ .Radio__indicator {

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -75,7 +75,7 @@
 
   &:focus ~ .Radio__indicator {
     border-color: $blue-100;
-    box-shadow: 0 0 11px rgba($blue-100, $alpha-500);
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), $alpha-500);
   }
 
   &:active ~ .Radio__indicator {
@@ -96,7 +96,7 @@
 
   &:checked:focus ~ .Radio__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba($blue-200, $alpha-400);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), $alpha-400);
   }
 
   &:checked:active:not(:disabled) ~ .Radio__indicator {

--- a/library/components/slider/_slider.scss
+++ b/library/components/slider/_slider.scss
@@ -51,7 +51,7 @@ $slider-focus-color: $blue-100;
   width: $slider-handle-size;
 
   &::after {
-    background-color: $slider-focus-color;
+    background-color: var(--focus-color);
     border-radius: 50%;
     bottom: $slider-focus-margin;
     box-shadow: 0 0 ($slider-focus-size / 2) 0 rgba($slider-focus-color, $alpha-700);
@@ -91,7 +91,7 @@ $slider-focus-color: $blue-100;
 }
 
 @mixin slider-green {
-  @include slider-color($green-200);
+  @include slider-color(var(--widget-on-color));
 }
 
 @include slider-green;

--- a/library/components/switch/_switch.scss
+++ b/library/components/switch/_switch.scss
@@ -47,7 +47,7 @@
   &::after {
     background-color: var(--focus-color);
     border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb), $alpha-700);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), $alpha-700);
     content: ' ';
     left: 50%;
     opacity: 0;

--- a/library/components/switch/_switch.scss
+++ b/library/components/switch/_switch.scss
@@ -64,7 +64,7 @@
   z-index: -1;
 
   &:checked ~ .Switch__indicator {
-    background-color: $green-200;
+    background-color: var(--widget-on-color);
 
     .Switch__toggler {
       right: $border-width;

--- a/library/components/switch/_switch.scss
+++ b/library/components/switch/_switch.scss
@@ -45,9 +45,9 @@
   transition: right .15s ease-out;
 
   &::after {
-    background-color: $blue-100;
+    background-color: var(--focus-color);
     border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba($blue-100, $alpha-700);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb), $alpha-700);
     content: ' ';
     left: 50%;
     opacity: 0;

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -43,7 +43,7 @@
 }
 
 .TextInput:focus {
-  border-color: $blue-100;
+  border-color: var(--focus-color);
   box-shadow: 0 0 11px rgba($blue-100, $alpha-500);
   outline: 0;
 }
@@ -59,7 +59,7 @@
 
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
-  border-color: $red;
+  border-color: var(--error-color);
 
   &.TextInput:focus {
     box-shadow: 0 0 11px rgba($red-100, $alpha-600);

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -36,7 +36,7 @@
   width: 100%;
 
   &::placeholder {
-    color: $text-color-hint;
+    color: var(--text-color-hint);
     // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526.
     opacity: 1;
   }
@@ -52,7 +52,7 @@
 .TextInput[readonly] {
   background: $gray-200;
   border-color: $gray-200;
-  color: $text-color-hint;
+  color: var(--text-color-hint);
   cursor: not-allowed;
   opacity: 1; // some browsers (e.g. iOS Safari) reduce opacity
 }

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -31,7 +31,7 @@
   -webkit-appearance: none;
   border: $border-width solid $gray-300;
   border-radius: $border-radius;
-  color: $text-color-primary;
+  color: var(--text-color-primary);
   line-height: $line-height-base;
   width: 100%;
 

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -44,7 +44,7 @@
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba($blue-100, $alpha-500);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb), $alpha-500);
   outline: 0;
 }
 
@@ -62,7 +62,7 @@
   border-color: var(--error-color);
 
   &.TextInput:focus {
-    box-shadow: 0 0 11px rgba($red-100, $alpha-600);
+    box-shadow: 0 0 11px rgba(var(--negative-color-rgb), $alpha-600);
   }
 }
 

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -44,7 +44,7 @@
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(var(--focus-color-rgb), $alpha-500);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), $alpha-500);
   outline: 0;
 }
 
@@ -62,7 +62,7 @@
   border-color: var(--error-color);
 
   &.TextInput:focus {
-    box-shadow: 0 0 11px rgba(var(--negative-color-rgb), $alpha-600);
+    box-shadow: 0 0 11px rgba(var(--negative-color-rgb-values), $alpha-600);
   }
 }
 

--- a/library/utilities/spacing/README.md
+++ b/library/utilities/spacing/README.md
@@ -29,7 +29,7 @@ Examples:
 
 ### SASS variables
 
-| Sass variable | Space |
+| SASS variable | Space |
 | -------- | ----- |
 | `$spacer-0` | 0 |
 | `$spacer-1` | 5px |

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -51,9 +51,9 @@
 .text-color-secondary { color: var(--text-color-secondary) !important; }
 .text-color-hint      { color: var(--text-color-hint)      !important; }
 
-.text-color-reversed-primary   { color: $text-color-reversed-primary   !important; }
-.text-color-reversed-secondary { color: $text-color-reversed-secondary !important; }
-.text-color-reversed-hint      { color: $text-color-reversed-hint      !important; }
+.text-color-reversed-primary   { color: var(--text-color-primary-reversed)   !important; }
+.text-color-reversed-secondary { color: var(--text-color-secondary-reversed) !important; }
+.text-color-reversed-hint      { color: var(--text-color-hint-reversed)      !important; }
 
 .text-color-orange { color: $orange !important; }
 .text-color-orange-100 { color: $orange-100 !important; }

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -47,7 +47,7 @@
 
 .text-color-inherit { color: inherit !important; }
 
-.text-color-primary   { color: $text-color-primary   !important; }
+.text-color-primary   { color: var(--text-color-primary)   !important; }
 .text-color-secondary { color: $text-color-secondary !important; }
 .text-color-hint      { color: $text-color-hint      !important; }
 

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -49,7 +49,7 @@
 
 .text-color-primary   { color: var(--text-color-primary)   !important; }
 .text-color-secondary { color: var(--text-color-secondary) !important; }
-.text-color-hint      { color: $text-color-hint      !important; }
+.text-color-hint      { color: var(--text-color-hint)      !important; }
 
 .text-color-reversed-primary   { color: $text-color-reversed-primary   !important; }
 .text-color-reversed-secondary { color: $text-color-reversed-secondary !important; }

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -48,7 +48,7 @@
 .text-color-inherit { color: inherit !important; }
 
 .text-color-primary   { color: var(--text-color-primary)   !important; }
-.text-color-secondary { color: $text-color-secondary !important; }
+.text-color-secondary { color: var(--text-color-secondary) !important; }
 .text-color-hint      { color: $text-color-hint      !important; }
 
 .text-color-reversed-primary   { color: $text-color-reversed-primary   !important; }

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -55,6 +55,14 @@
 .text-color-reversed-secondary { color: var(--text-color-secondary-reversed) !important; }
 .text-color-reversed-hint      { color: var(--text-color-hint-reversed)      !important; }
 
+.text-color-brand-primary  { color: var(--brand-color-primary) !important;}
+.text-color-brand-accent  { color: var(--brand-color-accent) !important;}
+.text-color-positive  { color: var(--positive-color) !important;}
+.text-color-negative  { color: var(--negative-color) !important;}
+.text-color-warning  { color: var(--warning-color) !important;}
+.text-color-interactive  { color: var(--interactive-color) !important;}
+.text-color-error  { color: var(--error-color) !important;}
+
 .text-color-orange { color: $orange !important; }
 .text-color-orange-100 { color: $orange-100 !important; }
 .text-color-orange-200 { color: $orange-200 !important; }

--- a/library/utilities/typography/_typography.scss
+++ b/library/utilities/typography/_typography.scss
@@ -56,12 +56,12 @@
 .text-color-reversed-hint      { color: var(--text-color-hint-reversed)      !important; }
 
 .text-color-brand-primary  { color: var(--brand-color-primary) !important;}
-.text-color-brand-accent  { color: var(--brand-color-accent) !important;}
-.text-color-positive  { color: var(--positive-color) !important;}
-.text-color-negative  { color: var(--negative-color) !important;}
-.text-color-warning  { color: var(--warning-color) !important;}
-.text-color-interactive  { color: var(--interactive-color) !important;}
-.text-color-error  { color: var(--error-color) !important;}
+.text-color-brand-accent   { color: var(--brand-color-accent) !important;}
+.text-color-positive       { color: var(--positive-color) !important;}
+.text-color-negative       { color: var(--negative-color) !important;}
+.text-color-warning        { color: var(--warning-color) !important;}
+.text-color-interactive    { color: var(--interactive-color) !important;}
+.text-color-error          { color: var(--error-color) !important;}
 
 .text-color-orange { color: $orange !important; }
 .text-color-orange-100 { color: $orange-100 !important; }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "fs-extra": "^9.0.1",
     "jsdom": "^11.0.0",
     "mocha": "^3.4.2",
+    "postcss": "^7.0.32",
+    "postcss-preset-env": "^6.7.0",
     "react-addons-test-utils": "15.4.2",
     "rollup": "^2.16.1",
     "sinon": "^2.3.2"

--- a/scripts/compileScss.js
+++ b/scripts/compileScss.js
@@ -1,15 +1,26 @@
 const path = require('path');
 const { promisify } = require('util');
 const nodeSass = require('node-sass');
-const fs = require('fs-extra');
-const outputFile = promisify(fs.outputFile);
+const postcss = require('postcss');
+const postcssPresetEnv = require('postcss-preset-env');
+const { outputFile, copy } = require('fs-extra');
+const renderSass = promisify(nodeSass.render);
 
 const PHENOTYPES = 'phenotypes';
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
 const DIST_DIR = path.resolve(WORKSPACE_ROOT, 'dist');
 const STYLES_DIR = path.resolve(WORKSPACE_ROOT, 'styles');
+const FRACTAL_CSS_ASSETS = path.resolve(
+  WORKSPACE_ROOT,
+  'fractal_assets',
+  'css'
+);
 const PHENOTYPES_SCSS = path.resolve(STYLES_DIR, `${PHENOTYPES}.scss`);
 const PHENOTYPES_CSS = path.resolve(STYLES_DIR, `${PHENOTYPES}.css`);
+const PHENOTYPES_THEMABLE_CSS = path.resolve(
+  STYLES_DIR,
+  `${PHENOTYPES}.themable.css`
+);
 
 function logGreen(text) {
   console.log(`\u001b[32m${text}\u001b[0m`);
@@ -19,25 +30,38 @@ function compileScss(changedPath) {
   if (changedPath) {
     console.log(`=> changed: ${changedPath}`);
   }
-  return nodeSass.render(
-    {
-      file: PHENOTYPES_SCSS,
-    },
-    (err, result) => {
-      if (err) {
-        console.error(err);
-      } else {
-        logGreen('Rendering Complete, saving .css file...');
-        outputFile(PHENOTYPES_CSS, result.css)
-          .then(() => {
-            logGreen(`Wrote CSS to ${PHENOTYPES_CSS}`);
-          })
-          .catch((err) => {
-            console.error('error:', err);
-          });
-      }
-    }
-  );
+  return renderSass({
+    file: PHENOTYPES_SCSS,
+  })
+    .then((result) => {
+      logGreen('Rendering Complete, saving.css files...');
+      return Promise.all([
+        Promise.resolve(result.css),
+        postcss([
+          postcssPresetEnv({
+            features: {
+              'custom-properties': {
+                preserve: false,
+              },
+            },
+          }),
+        ]).process(result.css),
+      ]);
+    })
+    .then(([cssThemable, { css: cssWithNoVariables }]) => {
+      return [
+        outputFile(PHENOTYPES_THEMABLE_CSS, cssThemable).then(() => {
+          logGreen(`Wrote themable CSS to ${PHENOTYPES_THEMABLE_CSS}`);
+          return copy(PHENOTYPES_THEMABLE_CSS, path.resolve(FRACTAL_CSS_ASSETS, 'phenotypes.themable.css'));
+        }),
+        outputFile(PHENOTYPES_CSS, cssWithNoVariables).then(() => {
+          logGreen(`Wrote non themable CSS to ${PHENOTYPES_CSS}`);
+        }),
+      ];
+    })
+    .catch((err) => {
+      console.error('error:', err);
+    });
 }
 
 module.exports = {

--- a/scripts/compileScss.js
+++ b/scripts/compileScss.js
@@ -52,7 +52,10 @@ function compileScss(changedPath) {
       return [
         outputFile(PHENOTYPES_THEMABLE_CSS, cssThemable).then(() => {
           logGreen(`Wrote themable CSS to ${PHENOTYPES_THEMABLE_CSS}`);
-          return copy(PHENOTYPES_THEMABLE_CSS, path.resolve(FRACTAL_CSS_ASSETS, 'phenotypes.themable.css'));
+          return copy(
+            PHENOTYPES_THEMABLE_CSS,
+            path.resolve(FRACTAL_CSS_ASSETS, 'phenotypes.themable.css')
+          );
         }),
         outputFile(PHENOTYPES_CSS, cssWithNoVariables).then(() => {
           logGreen(`Wrote non themable CSS to ${PHENOTYPES_CSS}`);
@@ -71,5 +74,6 @@ module.exports = {
     DIST_DIR,
     STYLES_DIR,
     PHENOTYPES_CSS,
+    PHENOTYPES_THEMABLE_CSS,
   },
 };

--- a/scripts/copyLibraryAssets.js
+++ b/scripts/copyLibraryAssets.js
@@ -3,7 +3,7 @@ const { promisify } = require('util');
 const fs = require('fs-extra');
 const copy = promisify(fs.copy);
 const {
-  paths: { DIST_DIR, STYLES_DIR, PHENOTYPES_CSS },
+  paths: { DIST_DIR, STYLES_DIR, PHENOTYPES_CSS, PHENOTYPES_THEMABLE_CSS },
   logGreen,
 } = require('./compileScss');
 
@@ -14,6 +14,12 @@ const DIST_CSS = path.resolve(DIST_DIR, 'css');
 function copyAssets() {
   copy(PHENOTYPES_CSS, path.resolve(DIST_CSS, 'phenotypes.css'))
     .then(() => logGreen('Copied phenotypes.css to dist directory.'))
+    .catch((err) => console.error(err));
+  copy(
+    PHENOTYPES_THEMABLE_CSS,
+    path.resolve(DIST_CSS, 'phenotypes.themable.css')
+  )
+    .then(() => logGreen(`Copied phenotypes.themable.css to dist directory.`))
     .catch((err) => console.error(err));
   copy(SAILEC_CSS, path.resolve(DIST_CSS, 'sailec.css'))
     .then(() => logGreen('Copied sailec.css to dist directory.'))

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -1,3 +1,4 @@
 @import 'mixins/breakpoints';
 @import 'mixins/depth';
 @import 'mixins/type';
+@import 'mixins/color';

--- a/styles/_reboot.scss
+++ b/styles/_reboot.scss
@@ -203,13 +203,13 @@ sup { top: -.5em; }
 //
 
 a {
-  color: $link-color;
+  color: var(--link-color);
   text-decoration: $link-decoration;
   background-color: transparent; // Remove the gray background on active links in IE 10.
   -webkit-text-decoration-skip: objects; // Remove gaps in links underline in iOS 8+ and Safari 8+.
 
   &:hover {
-    color: $link-hover-color;
+    color: var(--link-hover-color);
     text-decoration: $link-hover-decoration;
   }
 }

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -7,7 +7,7 @@
   --text-color-secondary-reversed: #{$text-color-reversed-secondary};
   --text-color-hint-reversed: #{$text-color-reversed-hint};
 
-  --brand-color-primary: #{$purple-300};
+  --brand-color-primary: #{$brand-primary};
   --message-info-bg-color: var(--brand-color-primary);
 
   --step-progress-active-color: #{$purple-200};
@@ -24,8 +24,7 @@
   --message-danger-bg-color: var(--error-color);
   --danger-button-color: var(--negative-color);
 
-  --warning-color: #{$orange-200};
-
+  --warning-color: #{$brand-warning};
 
   --interactive-color: #{$blue-200};
   --primary-button-color: var(--interactive-color);

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -19,7 +19,7 @@
 
   --message-success-bg-color: #{$green-300};
 
-  --negative-color: #{$red-200};
+  --negative-color: #{$brand-danger};
   --error-color: var(--negative-color);
   --message-danger-bg-color: var(--error-color);
   --danger-button-color: var(--negative-color);

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -7,23 +7,22 @@
   --text-color-secondary-reversed: #{$text-color-reversed-secondary};
   --text-color-hint-reversed: #{$text-color-reversed-hint};
 
-  --brand-color-primary: #{$brand-primary};
-  --brand-color-accent: #{$orange-200};
-  --positive-color: #{$green-200};
-  --negative-color: #{$brand-danger};
-  --warning-color: #{$brand-warning};
+  @include color-variable(--brand-color-primary, $brand-primary);
+  @include color-variable(--brand-color-accent, $orange-200);
+  @include color-variable(--positive-color, $green-200);
+  @include color-variable(--negative-color, $brand-danger);
+  @include color-variable(--warning-color, $brand-warning);
+  @include color-variable(--interactive-color, $blue-200);
   --error-color: var(--negative-color);
-  --interactive-color: #{$blue-200};
 
-
-  --step-progress-active-color: #{$purple-200};
-  --widget-on-color: var(--positive-color);
-  --focus-color: #{$blue-100};
   --link-color: var(--interactive-color);
-  --link-hover-color: #{$link-hover-color};
-  --link-color-reversed: #{$blue-100};
+  @include color-variable(--link-hover-color, $link-hover-color);
+  @include color-variable(--link-color-reversed, $blue-100);
+  @include color-variable(--step-progress-active-color, $purple-200);
+  @include color-variable(--focus-color, $blue-100);
+  --widget-on-color: var(--positive-color);
 
-  --message-success-bg-color: #{$green-300};
+  @include color-variable(--message-success-bg-color, $green-300);
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);
 

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -1,37 +1,36 @@
 :root {
   // base variable set
-  --text-color-primary: $text-color-primary;
-  --text-color-secondary: $text-color-secondary;
-  --text-color-hint: $text-color-hint;
-  --text-color-primary-reversed: $text-color-primary-reversed;
-  --text-color-secondary-reversed: $text-color-secondary-reversed;
-  --text-color-hint-reversed: $text-color-hint-reversed;
+  --text-color-primary: #{$text-color-primary};
+  --text-color-secondary: #{$text-color-secondary};
+  --text-color-hint: #{$text-color-hint};
+  --text-color-primary-reversed: #{$text-color-reversed-primary};
+  --text-color-secondary-reversed: #{$text-color-reversed-secondary};
+  --text-color-hint-reversed: #{$text-color-reversed-hint};
 
   --brand-color-primary: #{$purple-300};
-  --brand-color-accent-1: #{$purple-400};
+  --message-info-bg-color: var(--brand-color-primary);
 
-  --data-color: #{$green-200};
-  --data-color-reversed: #{$green-100};
+  --step-progress-active-color: #{$purple-200};
+
+  --brand-color-accent: #{$orange-200};
 
   --positive-color: #{$green-200};
   --widget-on-color: var(--positive-color);
-  --toast-success-bg-color: var(--positive-color);
+
+  --message-success-bg-color: #{$green-300};
 
   --negative-color: #{$red-200};
-  --toast-error-bg-color: var(--negative-color);
+  --error-color: var(--negative-color);
+  --message-danger-bg-color: var(--error-color);
+  --danger-button-color: var(--negative-color);
 
   --warning-color: #{$orange-200};
 
+
   --interactive-color: #{$blue-200};
-  --toast-info-bg-color: var(--interactive-color);
   --primary-button-color: var(--interactive-color);
   --link-color: var(--interactive-color);
-
-  --bg-color-light: #{$gray-100};
-  --bg-color-dark: #{$gray-800};
-
-
   --link-color-reversed: #{$blue-100};
+
   --focus-color:#{blue-100};
-  --typeahead-selection-color:
 }

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -1,3 +1,9 @@
+// ------------------------------
+// NOTE:
+// These variables are replicated in the documentation website
+// for Phenotypes. Plase make sure that the theming guide at ./guides/11-theming.md
+// is updated with any new variables that are added.
+// ------------------------------
 :root {
   // base variable set
   --text-color-primary: #{$text-color-primary};

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -20,6 +20,7 @@
   --widget-on-color: var(--positive-color);
   --focus-color: #{$blue-100};
   --link-color: var(--interactive-color);
+  --link-hover-color: #{$link-hover-color};
   --link-color-reversed: #{$blue-100};
 
   --message-success-bg-color: #{$green-300};

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -1,0 +1,37 @@
+:root {
+  // base variable set
+  --text-color-primary: $text-color-primary;
+  --text-color-secondary: $text-color-secondary;
+  --text-color-hint: $text-color-hint;
+  --text-color-primary-reversed: $text-color-primary-reversed;
+  --text-color-secondary-reversed: $text-color-secondary-reversed;
+  --text-color-hint-reversed: $text-color-hint-reversed;
+
+  --brand-color-primary: #{$purple-300};
+  --brand-color-accent-1: #{$purple-400};
+
+  --data-color: #{$green-200};
+  --data-color-reversed: #{$green-100};
+
+  --positive-color: #{$green-200};
+  --widget-on-color: var(--positive-color);
+  --toast-success-bg-color: var(--positive-color);
+
+  --negative-color: #{$red-200};
+  --toast-error-bg-color: var(--negative-color);
+
+  --warning-color: #{$orange-200};
+
+  --interactive-color: #{$blue-200};
+  --toast-info-bg-color: var(--interactive-color);
+  --primary-button-color: var(--interactive-color);
+  --link-color: var(--interactive-color);
+
+  --bg-color-light: #{$gray-100};
+  --bg-color-dark: #{$gray-800};
+
+
+  --link-color-reversed: #{$blue-100};
+  --focus-color:#{blue-100};
+  --typeahead-selection-color:
+}

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -31,5 +31,5 @@
   --link-color: var(--interactive-color);
   --link-color-reversed: #{$blue-100};
 
-  --focus-color:#{blue-100};
+  --focus-color: #{$blue-100};
 }

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -8,28 +8,29 @@
   --text-color-hint-reversed: #{$text-color-reversed-hint};
 
   --brand-color-primary: #{$brand-primary};
-  --message-info-bg-color: var(--brand-color-primary);
+  --brand-color-accent: #{$orange-200};
+  --positive-color: #{$green-200};
+  --negative-color: #{$brand-danger};
+  --warning-color: #{$brand-warning};
+  --error-color: var(--negative-color);
+  --interactive-color: #{$blue-200};
+
 
   --step-progress-active-color: #{$purple-200};
-
-  --brand-color-accent: #{$orange-200};
-
-  --positive-color: #{$green-200};
   --widget-on-color: var(--positive-color);
-
-  --message-success-bg-color: #{$green-300};
-
-  --negative-color: #{$brand-danger};
-  --error-color: var(--negative-color);
-  --message-danger-bg-color: var(--error-color);
-  --danger-button-color: var(--negative-color);
-
-  --warning-color: #{$brand-warning};
-
-  --interactive-color: #{$blue-200};
-  --primary-button-color: var(--interactive-color);
+  --focus-color: #{$blue-100};
   --link-color: var(--interactive-color);
   --link-color-reversed: #{$blue-100};
 
-  --focus-color: #{$blue-100};
+  --message-success-bg-color: #{$green-300};
+  --message-info-bg-color: var(--brand-color-primary);
+  --message-danger-bg-color: var(--error-color);
+
+  --danger-button-color: var(--negative-color);
+  --danger-button-focus-color: #ee3548;
+  --danger-button-active-color: #ec192e;
+
+  --primary-button-color: var(--interactive-color);
+  --primary-button-focus-color: #14a5c9;
+  --primary-button-active-color: #118ead;
 }

--- a/styles/mixins/_color.scss
+++ b/styles/mixins/_color.scss
@@ -1,0 +1,42 @@
+// ------------------------------
+// Color functions
+// ------------------------------
+
+// extract-rgb
+// accepts a color and extracts a triplet of rgb values
+// extract-rgb(#32a852) = 50, 168, 82
+@function extract-rgb($color-value) {
+  @return red($color-value), green($color-value), blue($color-value);
+}
+
+
+// ------------------------------
+// Color mixins
+// ------------------------------
+
+// creates a two css custom properties based on a variable name
+// ex:
+// input scss:
+// @include color-variable(--progress-bar-active-color, $purple-200)
+
+// output css:
+// --progress-bar-active-color-rgb: 179, 93, 186;
+// --progress-bar-active-color: rgb(var(--progress-bar-active-color-rgb))
+//
+// this is useful for theming elements that require alpha channels as
+// we can use the rgb variable to interpolate the rgb values into a
+// css rgba function and apply and alpha channel
+// ex:
+// background-color: var(--progress-bar-active-color);
+// box-shadow: box-shadow: 0 0 modular-scale-px(-6) 0
+//      rgba(var(--step-progress-active-color-rgb), $alpha-600)
+
+// this works becuase the values of css variables are treated as strings
+// and they do not have any contextual knowledge of how they should be applied
+// css variable values are at runtime essentially string substitutions.
+@mixin color-variable($variable-name, $variable-value) {
+    $rgb-variable-name: #{$variable-name}-rgb;
+
+    #{$rgb-variable-name}: #{extract-rgb($variable-value)};
+    #{$variable-name}: unquote("rgb(var(#{$rgb-variable-name}))");
+}

--- a/styles/mixins/_color.scss
+++ b/styles/mixins/_color.scss
@@ -20,8 +20,8 @@
 // @include color-variable(--progress-bar-active-color, $purple-200)
 
 // output css:
-// --progress-bar-active-color-rgb: 179, 93, 186;
-// --progress-bar-active-color: rgb(var(--progress-bar-active-color-rgb))
+// --progress-bar-active-color-rgb-values: 179, 93, 186;
+// --progress-bar-active-color: rgb(var(--progress-bar-active-color-rgb-values))
 //
 // this is useful for theming elements that require alpha channels as
 // we can use the rgb variable to interpolate the rgb values into a
@@ -29,13 +29,13 @@
 // ex:
 // background-color: var(--progress-bar-active-color);
 // box-shadow: box-shadow: 0 0 modular-scale-px(-6) 0
-//      rgba(var(--step-progress-active-color-rgb), $alpha-600)
+//      rgba(var(--step-progress-active-color-rgb-values), $alpha-600)
 
 // this works becuase the values of css variables are treated as strings
 // and they do not have any contextual knowledge of how they should be applied
 // css variable values are at runtime essentially string substitutions.
 @mixin color-variable($variable-name, $variable-value) {
-    $rgb-variable-name: #{$variable-name}-rgb;
+    $rgb-variable-name: #{$variable-name}-rgb-values;
 
     #{$rgb-variable-name}: #{extract-rgb($variable-value)};
     #{$variable-name}: unquote("rgb(var(#{$rgb-variable-name}))");

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -166,12 +166,12 @@ sup {
   top: -.5em; }
 
 a {
-  color: #16b8e0;
+  color: rgb(22, 184, 224);
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
   a:hover {
-    color: #008ab3;
+    color: rgb(0, 138, 179);
     text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {
@@ -431,7 +431,7 @@ hr {
   cursor: not-allowed; }
 
 .Button--danger .Button__control {
-  background: #f04d5d;
+  background: rgb(240, 77, 93);
   color: #fff;
   font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
@@ -444,7 +444,7 @@ hr {
 
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
-  background: #16b8e0;
+  background: rgb(22, 184, 224);
   color: #fff;
   font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
@@ -798,15 +798,15 @@ hr {
   padding: 16px; }
 
 .Message--success {
-  background-color: #03ab8c;
+  background-color: rgb(3, 171, 140);
   color: #fff; }
 
 .Message--info {
-  background-color: #853b94;
+  background-color: rgb(133, 59, 148);
   color: #fff; }
 
 .Message--danger {
-  background-color: #f04d5d;
+  background-color: rgb(240, 77, 93);
   color: #fff; }
 
 .Radio {
@@ -1138,12 +1138,12 @@ hr {
   .ProgressBar__step:last-child {
     margin-right: 0; }
   .ProgressBar__step::after {
-    background-color: #b35dba;
-    box-shadow: 0 0 7px 0 #e39ae3;
-    content: ' ';
+    background-color: rgb(179, 93, 186);
+    box-shadow: 0 0 7px 0 rgba(179, 93, 186, 0.54);
+    content: " ";
     height: 100%;
     opacity: 0;
-    transition: opacity .2s linear;
+    transition: opacity 0.2s linear;
     width: 100%; }
 
 .ProgressBar__step--active::after {
@@ -1187,7 +1187,7 @@ hr {
   top: -10px;
   width: 24px; }
   .Slider__handle::after {
-    background-color: #7feaff;
+    background-color: rgb(127, 234, 255);
     border-radius: 50%;
     bottom: 7px;
     box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
@@ -1210,7 +1210,7 @@ hr {
   background-color: rgba(0, 0, 0, 0.14); }
 
 .Slider__fill {
-  background-color: #2dcfa1; }
+  background-color: rgb(45, 207, 161); }
 
 .Slider__handle {
   background-color: #fff; }
@@ -1243,7 +1243,7 @@ hr {
   top: 2px;
   transition: right .15s ease-out; }
   .Switch__toggler::after {
-    background-color: #7feaff;
+    background-color: rgb(127, 234, 255);
     border-radius: 50%;
     box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
     content: ' ';
@@ -1259,7 +1259,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Switch__input:checked ~ .Switch__indicator {
-    background-color: #2dcfa1; }
+    background-color: rgb(45, 207, 161); }
     .Switch__input:checked ~ .Switch__indicator .Switch__toggler {
       right: 2px; }
   .Switch__input:disabled ~ .Switch__indicator {
@@ -1300,7 +1300,7 @@ hr {
     opacity: 1; }
 
 .TextInput:focus {
-  border-color: #7feaff;
+  border-color: rgb(127, 234, 255);
   box-shadow: 0 0 11px rgba(127, 234, 255, 0.41);
   outline: 0; }
 
@@ -1314,10 +1314,10 @@ hr {
 
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
-  border-color: #f04d5d; }
+  border-color: rgb(240, 77, 93); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
-    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+    box-shadow: 0 0 11px rgba(240, 77, 93, 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {
@@ -1402,7 +1402,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: #f04d5d;
+  color: rgb(240, 77, 93);
   margin-top: 7px; }
   .FormGroup__error::before {
     content: '✘ ';
@@ -1441,7 +1441,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: #f04d5d;
+  color: rgb(240, 77, 93);
   margin-top: 7px; }
   .FormGroup--medium .FormGroup__error::before {
     content: '✘ ';
@@ -1496,7 +1496,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: rgb(240, 77, 93);
     margin-top: 7px; }
     .FormGroup--medium-sm .FormGroup__error::before {
       content: '✘ ';
@@ -1547,7 +1547,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: rgb(240, 77, 93);
     margin-top: 7px; }
     .FormGroup--medium-md .FormGroup__error::before {
       content: '✘ ';
@@ -1598,7 +1598,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: rgb(240, 77, 93);
     margin-top: 7px; }
     .FormGroup--medium-lg .FormGroup__error::before {
       content: '✘ ';
@@ -1649,7 +1649,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: rgb(240, 77, 93);
     margin-top: 7px; }
     .FormGroup--medium-xl .FormGroup__error::before {
       content: '✘ ';

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -6001,6 +6001,27 @@ hr {
 .text-color-reversed-hint {
   color: rgba(255, 255, 255, 0.59) !important; }
 
+.text-color-brand-primary {
+  color: rgb(133, 59, 148) !important; }
+
+.text-color-brand-accent {
+  color: rgb(252, 134, 38) !important; }
+
+.text-color-positive {
+  color: rgb(45, 207, 161) !important; }
+
+.text-color-negative {
+  color: rgb(240, 77, 93) !important; }
+
+.text-color-warning {
+  color: rgb(252, 134, 38) !important; }
+
+.text-color-interactive {
+  color: rgb(22, 184, 224) !important; }
+
+.text-color-error {
+  color: rgb(240, 77, 93) !important; }
+
 .text-color-orange {
   color: #fc8626 !important; }
 

--- a/styles/phenotypes.scss
+++ b/styles/phenotypes.scss
@@ -25,6 +25,10 @@
 @import 'variables';
 @import 'mixins';
 
+// Theme specific css variables
+// NOT sass variables
+@import 'theme_config';
+
 // Reboot/normalize
 @import 'reboot';
 

--- a/styles/phenotypes.scss
+++ b/styles/phenotypes.scss
@@ -26,7 +26,7 @@
 @import 'mixins';
 
 // Theme specific css variables
-// NOT sass variables
+// NOT SASS variables
 @import 'theme_config';
 
 // Reboot/normalize

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -86,7 +86,7 @@
   --primary-button-color: var(--interactive-color);
   --link-color: var(--interactive-color);
   --link-color-reversed: #7feaff;
-  --focus-color:blue-100; }
+  --focus-color: #7feaff; }
 
 html {
   box-sizing: border-box;
@@ -1205,7 +1205,7 @@ hr {
   top: -10px;
   width: 24px; }
   .Slider__handle::after {
-    background-color: #7feaff;
+    background-color: var(--focus-color);
     border-radius: 50%;
     bottom: 7px;
     box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
@@ -1228,7 +1228,7 @@ hr {
   background-color: rgba(0, 0, 0, 0.14); }
 
 .Slider__fill {
-  background-color: #2dcfa1; }
+  background-color: var(--widget-on-color); }
 
 .Slider__handle {
   background-color: #fff; }

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -1309,7 +1309,7 @@ hr {
     opacity: 1; }
 
 .TextInput:focus {
-  border-color: #7feaff;
+  border-color: var(--focus-color);
   box-shadow: 0 0 11px rgba(127, 234, 255, 0.41);
   outline: 0; }
 
@@ -1323,7 +1323,7 @@ hr {
 
 .TextInput--has-error,
 .FormGroup--has-error .TextInput {
-  border-color: #f04d5d; }
+  border-color: var(--error-color); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
     box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
@@ -1411,7 +1411,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: #f04d5d;
+  color: var(--error-color);
   margin-top: 7px; }
   .FormGroup__error::before {
     content: '✘ ';
@@ -1450,7 +1450,7 @@ hr {
   line-height: 21px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: #f04d5d;
+  color: var(--error-color);
   margin-top: 7px; }
   .FormGroup--medium .FormGroup__error::before {
     content: '✘ ';
@@ -1505,7 +1505,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-sm .FormGroup__error::before {
       content: '✘ ';
@@ -1556,7 +1556,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-md .FormGroup__error::before {
       content: '✘ ';
@@ -1607,7 +1607,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-lg .FormGroup__error::before {
       content: '✘ ';
@@ -1658,7 +1658,7 @@ hr {
     line-height: 21px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: #f04d5d;
+    color: var(--error-color);
     margin-top: 7px; }
     .FormGroup--medium-xl .FormGroup__error::before {
       content: '✘ ';

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -71,22 +71,26 @@
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
   --brand-color-primary: #853b94;
-  --message-info-bg-color: var(--brand-color-primary);
-  --step-progress-active-color: #b35dba;
   --brand-color-accent: #fc8626;
   --positive-color: #2dcfa1;
-  --widget-on-color: var(--positive-color);
-  --message-success-bg-color: #03ab8c;
   --negative-color: #f04d5d;
-  --error-color: var(--negative-color);
-  --message-danger-bg-color: var(--error-color);
-  --danger-button-color: var(--negative-color);
   --warning-color: #fc8626;
+  --error-color: var(--negative-color);
   --interactive-color: #16b8e0;
-  --primary-button-color: var(--interactive-color);
+  --step-progress-active-color: #b35dba;
+  --widget-on-color: var(--positive-color);
+  --focus-color: #7feaff;
   --link-color: var(--interactive-color);
   --link-color-reversed: #7feaff;
-  --focus-color: #7feaff; }
+  --message-success-bg-color: #03ab8c;
+  --message-info-bg-color: var(--brand-color-primary);
+  --message-danger-bg-color: var(--error-color);
+  --danger-button-color: var(--negative-color);
+  --danger-button-focus-color: #ee3548;
+  --danger-button-active-color: #ec192e;
+  --primary-button-color: var(--interactive-color);
+  --primary-button-focus-color: #14a5c9;
+  --primary-button-active-color: #118ead; }
 
 html {
   box-sizing: border-box;
@@ -455,31 +459,31 @@ hr {
   cursor: not-allowed; }
 
 .Button--danger .Button__control {
-  background: #f04d5d;
+  background: var(--danger-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
-    background: #ee3548;
+    background: var(--danger-button-focus-color);
     color: #fff; }
 
 .Button--danger .Button__control:active,
 .Button--danger.Button--is-active .Button__control {
-  background: #ec192e; }
+  background: var(--danger-button-active-color); }
 
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
-  background: #16b8e0;
+  background: var(--primary-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
-    background: #14a5c9;
+    background: var(--primary-button-focus-color);
     color: #fff; }
 
 .Button--primary .Button__control:active,
 .Button--primary.Button--is-active .Button__control {
   box-shadow: none;
-  background: #118ead; }
+  background: var(--primary-button-active-color); }
 
 .Button--link .Button__control .Button__control {
   background: transparent;

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -70,31 +70,31 @@
   --text-color-primary-reversed: #fff;
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
-  --brand-color-primary-rgb: 133, 59, 148;
-  --brand-color-primary: rgb(var(--brand-color-primary-rgb));
-  --brand-color-accent-rgb: 252, 134, 38;
-  --brand-color-accent: rgb(var(--brand-color-accent-rgb));
-  --positive-color-rgb: 45, 207, 161;
-  --positive-color: rgb(var(--positive-color-rgb));
-  --negative-color-rgb: 240, 77, 93;
-  --negative-color: rgb(var(--negative-color-rgb));
-  --warning-color-rgb: 252, 134, 38;
-  --warning-color: rgb(var(--warning-color-rgb));
-  --interactive-color-rgb: 22, 184, 224;
-  --interactive-color: rgb(var(--interactive-color-rgb));
+  --brand-color-primary-rgb-values: 133, 59, 148;
+  --brand-color-primary: rgb(var(--brand-color-primary-rgb-values));
+  --brand-color-accent-rgb-values: 252, 134, 38;
+  --brand-color-accent: rgb(var(--brand-color-accent-rgb-values));
+  --positive-color-rgb-values: 45, 207, 161;
+  --positive-color: rgb(var(--positive-color-rgb-values));
+  --negative-color-rgb-values: 240, 77, 93;
+  --negative-color: rgb(var(--negative-color-rgb-values));
+  --warning-color-rgb-values: 252, 134, 38;
+  --warning-color: rgb(var(--warning-color-rgb-values));
+  --interactive-color-rgb-values: 22, 184, 224;
+  --interactive-color: rgb(var(--interactive-color-rgb-values));
   --error-color: var(--negative-color);
   --link-color: var(--interactive-color);
-  --link-hover-color-rgb: 0, 138, 179;
-  --link-hover-color: rgb(var(--link-hover-color-rgb));
-  --link-color-reversed-rgb: 127, 234, 255;
-  --link-color-reversed: rgb(var(--link-color-reversed-rgb));
-  --step-progress-active-color-rgb: 179, 93, 186;
-  --step-progress-active-color: rgb(var(--step-progress-active-color-rgb));
-  --focus-color-rgb: 127, 234, 255;
-  --focus-color: rgb(var(--focus-color-rgb));
+  --link-hover-color-rgb-values: 0, 138, 179;
+  --link-hover-color: rgb(var(--link-hover-color-rgb-values));
+  --link-color-reversed-rgb-values: 127, 234, 255;
+  --link-color-reversed: rgb(var(--link-color-reversed-rgb-values));
+  --step-progress-active-color-rgb-values: 179, 93, 186;
+  --step-progress-active-color: rgb(var(--step-progress-active-color-rgb-values));
+  --focus-color-rgb-values: 127, 234, 255;
+  --focus-color: rgb(var(--focus-color-rgb-values));
   --widget-on-color: var(--positive-color);
-  --message-success-bg-color-rgb: 3, 171, 140;
-  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb));
+  --message-success-bg-color-rgb-values: 3, 171, 140;
+  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);
   --danger-button-color: var(--negative-color);
@@ -600,7 +600,7 @@ hr {
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -610,7 +610,7 @@ hr {
     border-color: #232323; }
   .Checkbox__input:checked:focus ~ .Checkbox__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
   .Checkbox__input:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
     background-color: #232323;
@@ -871,7 +871,7 @@ hr {
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -883,7 +883,7 @@ hr {
       display: block; }
   .Radio__input:checked:focus ~ .Radio__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
   .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
     background-color: #232323;
     border-color: #232323; }
@@ -1173,7 +1173,7 @@ hr {
     margin-right: 0; }
   .ProgressBar__step::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb), 0.54);
+    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb-values), 0.54);
     content: " ";
     height: 100%;
     opacity: 0;
@@ -1279,7 +1279,7 @@ hr {
   .Switch__toggler::after {
     background-color: var(--focus-color);
     border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb), 0.7);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), 0.7);
     content: ' ';
     left: 50%;
     opacity: 0;
@@ -1326,7 +1326,7 @@ hr {
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41);
   outline: 0; }
 
 .TextInput:disabled,
@@ -1342,7 +1342,7 @@ hr {
   border-color: var(--error-color); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
-    box-shadow: 0 0 11px rgba(var(--negative-color-rgb), 0.54); }
+    box-shadow: 0 0 11px rgba(var(--negative-color-rgb-values), 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -63,6 +63,34 @@
   src: url("webfonts/33AD5D_3_0.eot");
   src: url("webfonts/33AD5D_3_0.eot?#iefix") format("embedded-opentype"), url("webfonts/33AD5D_3_0.woff2") format("woff2"), url("webfonts/33AD5D_3_0.woff") format("woff"), url("webfonts/33AD5D_3_0.ttf") format("truetype"); }
 
+:root {
+  --text-color-primary: $text-color-primary;
+  --text-color-secondary: $text-color-secondary;
+  --text-color-hint: $text-color-hint;
+  --text-color-primary-reversed: $text-color-primary-reversed;
+  --text-color-secondary-reversed: $text-color-secondary-reversed;
+  --text-color-hint-reversed: $text-color-hint-reversed;
+  --brand-color-primary: #853b94;
+  --brand-color-accent-1: #58166e;
+  --data-color: #2dcfa1;
+  --data-color-reversed: #89f0cf;
+  --positive-color: #2dcfa1;
+  --widget-on-color: var(--positive-color);
+  --toast-success-bg-color: var(--positive-color);
+  --negative-color: #f04d5d;
+  --toast-error-bg-color: var(--negative-color);
+  --warning-color: #fc8626;
+  --interactive-color: #16b8e0;
+  --toast-info-bg-color: var(--interactive-color);
+  --primary-button-color: var(--interactive-color);
+  --link-color: var(--interactive-color);
+  --bg-color-light: #f9f9f9;
+  --bg-color-dark: #232323;
+  --link-color-reversed: #7feaff;
+  --focus-color:blue-100;
+  --typeahead-selection-color:
+; }
+
 html {
   box-sizing: border-box;
   font-family: sans-serif;
@@ -110,8 +138,7 @@ p {
 abbr[title],
 abbr[data-original-title] {
   text-decoration: underline;
-  -webkit-text-decoration: underline dotted;
-          text-decoration: underline dotted;
+  text-decoration: underline dotted;
   cursor: help;
   border-bottom: 0; }
 
@@ -593,10 +620,7 @@ hr {
   left: 0;
   pointer-events: none;
   position: absolute;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none; }
+  user-select: none; }
 
 .Checkbox--is-disabled {
   cursor: not-allowed; }
@@ -869,10 +893,7 @@ hr {
   left: 0;
   pointer-events: none;
   position: absolute;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none; }
+  user-select: none; }
   .Radio__indicator::after {
     background-color: #fff;
     border-radius: 50%;
@@ -1286,15 +1307,6 @@ hr {
   color: rgba(0, 0, 0, 0.86);
   line-height: 1.49271;
   width: 100%; }
-  .TextInput::-moz-placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
-  .TextInput:-ms-input-placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
-  .TextInput::-ms-input-placeholder {
-    color: rgba(0, 0, 0, 0.41);
-    opacity: 1; }
   .TextInput::placeholder {
     color: rgba(0, 0, 0, 0.41);
     opacity: 1; }

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -70,20 +70,31 @@
   --text-color-primary-reversed: #fff;
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
-  --brand-color-primary: #853b94;
-  --brand-color-accent: #fc8626;
-  --positive-color: #2dcfa1;
-  --negative-color: #f04d5d;
-  --warning-color: #fc8626;
+  --brand-color-primary-rgb: 133, 59, 148;
+  --brand-color-primary: rgb(var(--brand-color-primary-rgb));
+  --brand-color-accent-rgb: 252, 134, 38;
+  --brand-color-accent: rgb(var(--brand-color-accent-rgb));
+  --positive-color-rgb: 45, 207, 161;
+  --positive-color: rgb(var(--positive-color-rgb));
+  --negative-color-rgb: 240, 77, 93;
+  --negative-color: rgb(var(--negative-color-rgb));
+  --warning-color-rgb: 252, 134, 38;
+  --warning-color: rgb(var(--warning-color-rgb));
+  --interactive-color-rgb: 22, 184, 224;
+  --interactive-color: rgb(var(--interactive-color-rgb));
   --error-color: var(--negative-color);
-  --interactive-color: #16b8e0;
-  --step-progress-active-color: #b35dba;
-  --widget-on-color: var(--positive-color);
-  --focus-color: #7feaff;
   --link-color: var(--interactive-color);
-  --link-hover-color: #008ab3;
-  --link-color-reversed: #7feaff;
-  --message-success-bg-color: #03ab8c;
+  --link-hover-color-rgb: 0, 138, 179;
+  --link-hover-color: rgb(var(--link-hover-color-rgb));
+  --link-color-reversed-rgb: 127, 234, 255;
+  --link-color-reversed: rgb(var(--link-color-reversed-rgb));
+  --step-progress-active-color-rgb: 179, 93, 186;
+  --step-progress-active-color: rgb(var(--step-progress-active-color-rgb));
+  --focus-color-rgb: 127, 234, 255;
+  --focus-color: rgb(var(--focus-color-rgb));
+  --widget-on-color: var(--positive-color);
+  --message-success-bg-color-rgb: 3, 171, 140;
+  --message-success-bg-color: rgb(var(--message-success-bg-color-rgb));
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);
   --danger-button-color: var(--negative-color);
@@ -589,7 +600,7 @@ hr {
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -599,7 +610,7 @@ hr {
     border-color: #232323; }
   .Checkbox__input:checked:focus ~ .Checkbox__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
   .Checkbox__input:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
     background-color: #232323;
@@ -860,7 +871,7 @@ hr {
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -872,7 +883,7 @@ hr {
       display: block; }
   .Radio__input:checked:focus ~ .Radio__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(22, 184, 224, 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb), 0.24); }
   .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
     background-color: #232323;
     border-color: #232323; }
@@ -1162,11 +1173,11 @@ hr {
     margin-right: 0; }
   .ProgressBar__step::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 7px 0 #e39ae3;
-    content: ' ';
+    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb), 0.54);
+    content: " ";
     height: 100%;
     opacity: 0;
-    transition: opacity .2s linear;
+    transition: opacity 0.2s linear;
     width: 100%; }
 
 .ProgressBar__step--active::after {
@@ -1266,9 +1277,9 @@ hr {
   top: 2px;
   transition: right .15s ease-out; }
   .Switch__toggler::after {
-    background-color: #7feaff;
+    background-color: var(--focus-color);
     border-radius: 50%;
-    box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb), 0.7);
     content: ' ';
     left: 50%;
     opacity: 0;
@@ -1315,7 +1326,7 @@ hr {
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(127, 234, 255, 0.41);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb), 0.41);
   outline: 0; }
 
 .TextInput:disabled,
@@ -1331,7 +1342,7 @@ hr {
   border-color: var(--error-color); }
   .TextInput--has-error.TextInput:focus,
   .FormGroup--has-error .TextInput.TextInput:focus {
-    box-shadow: 0 0 11px rgba(255, 151, 154, 0.54); }
+    box-shadow: 0 0 11px rgba(var(--negative-color-rgb), 0.54); }
 
 .TextInput--medium,
 .FormGroup--medium .TextInput {

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -1282,7 +1282,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Switch__input:checked ~ .Switch__indicator {
-    background-color: #2dcfa1; }
+    background-color: var(--widget-on-color); }
     .Switch__input:checked ~ .Switch__indicator .Switch__toggler {
       right: 2px; }
   .Switch__input:disabled ~ .Switch__indicator {

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -819,15 +819,15 @@ hr {
   padding: 16px; }
 
 .Message--success {
-  background-color: #03ab8c;
+  background-color: var(--message-success-bg-color);
   color: #fff; }
 
 .Message--info {
-  background-color: #853b94;
+  background-color: var(--message-info-bg-color);
   color: #fff; }
 
 .Message--danger {
-  background-color: #f04d5d;
+  background-color: var(--message-danger-bg-color);
   color: #fff; }
 
 .Radio {

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -1305,7 +1305,7 @@ hr {
   line-height: 1.49271;
   width: 100%; }
   .TextInput::placeholder {
-    color: rgba(0, 0, 0, 0.41);
+    color: var(--text-color-hint);
     opacity: 1; }
 
 .TextInput:focus {
@@ -1317,7 +1317,7 @@ hr {
 .TextInput[readonly] {
   background: #eee;
   border-color: #eee;
-  color: rgba(0, 0, 0, 0.41);
+  color: var(--text-color-hint);
   cursor: not-allowed;
   opacity: 1; }
 
@@ -5999,7 +5999,7 @@ hr {
   color: var(--text-color-secondary) !important; }
 
 .text-color-hint {
-  color: rgba(0, 0, 0, 0.41) !important; }
+  color: var(--text-color-hint) !important; }
 
 .text-color-reversed-primary {
   color: #fff !important; }

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -81,6 +81,7 @@
   --widget-on-color: var(--positive-color);
   --focus-color: #7feaff;
   --link-color: var(--interactive-color);
+  --link-hover-color: #008ab3;
   --link-color-reversed: #7feaff;
   --message-success-bg-color: #03ab8c;
   --message-info-bg-color: var(--brand-color-primary);
@@ -194,12 +195,12 @@ sup {
   top: -.5em; }
 
 a {
-  color: #16b8e0;
+  color: var(--link-color);
   text-decoration: none;
   background-color: transparent;
   -webkit-text-decoration-skip: objects; }
   a:hover {
-    color: #008ab3;
+    color: var(--link-hover-color);
     text-decoration: underline; }
 
 a:not([href]):not([tabindex]) {

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -1156,7 +1156,7 @@ hr {
   .ProgressBar__step:last-child {
     margin-right: 0; }
   .ProgressBar__step::after {
-    background-color: #b35dba;
+    background-color: var(--step-progress-active-color);
     box-shadow: 0 0 7px 0 #e39ae3;
     content: ' ';
     height: 100%;

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -6002,13 +6002,13 @@ hr {
   color: var(--text-color-hint) !important; }
 
 .text-color-reversed-primary {
-  color: #fff !important; }
+  color: var(--text-color-primary-reversed) !important; }
 
 .text-color-reversed-secondary {
-  color: rgba(255, 255, 255, 0.76) !important; }
+  color: var(--text-color-secondary-reversed) !important; }
 
 .text-color-reversed-hint {
-  color: rgba(255, 255, 255, 0.59) !important; }
+  color: var(--text-color-hint-reversed) !important; }
 
 .text-color-orange {
   color: #fc8626 !important; }

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -410,7 +410,7 @@ hr {
   background: rgba(0, 0, 0, 0.07);
   border: 0;
   border-radius: 3px;
-  color: rgba(0, 0, 0, 0.86);
+  color: var(--text-color-primary);
   cursor: pointer;
   display: inline-block;
   font-weight: normal;
@@ -429,7 +429,7 @@ hr {
 .Button__control:focus {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   background: rgba(0, 0, 0, 0.12);
-  color: rgba(0, 0, 0, 0.86);
+  color: var(--text-color-primary);
   text-decoration: none;
   transform: translateY(-2.25px) scaleX(1.015) scaleY(1.015);
   transition-duration: .08s; }
@@ -1301,7 +1301,7 @@ hr {
   -webkit-appearance: none;
   border: 2px solid #dbdbdb;
   border-radius: 3px;
-  color: rgba(0, 0, 0, 0.86);
+  color: var(--text-color-primary);
   line-height: 1.49271;
   width: 100%; }
   .TextInput::placeholder {
@@ -5993,7 +5993,7 @@ hr {
   color: inherit !important; }
 
 .text-color-primary {
-  color: rgba(0, 0, 0, 0.86) !important; }
+  color: var(--text-color-primary) !important; }
 
 .text-color-secondary {
   color: rgba(0, 0, 0, 0.54) !important; }

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -64,32 +64,29 @@
   src: url("webfonts/33AD5D_3_0.eot?#iefix") format("embedded-opentype"), url("webfonts/33AD5D_3_0.woff2") format("woff2"), url("webfonts/33AD5D_3_0.woff") format("woff"), url("webfonts/33AD5D_3_0.ttf") format("truetype"); }
 
 :root {
-  --text-color-primary: $text-color-primary;
-  --text-color-secondary: $text-color-secondary;
-  --text-color-hint: $text-color-hint;
-  --text-color-primary-reversed: $text-color-primary-reversed;
-  --text-color-secondary-reversed: $text-color-secondary-reversed;
-  --text-color-hint-reversed: $text-color-hint-reversed;
+  --text-color-primary: rgba(0, 0, 0, 0.86);
+  --text-color-secondary: rgba(0, 0, 0, 0.54);
+  --text-color-hint: rgba(0, 0, 0, 0.41);
+  --text-color-primary-reversed: #fff;
+  --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
+  --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
   --brand-color-primary: #853b94;
-  --brand-color-accent-1: #58166e;
-  --data-color: #2dcfa1;
-  --data-color-reversed: #89f0cf;
+  --message-info-bg-color: var(--brand-color-primary);
+  --step-progress-active-color: #b35dba;
+  --brand-color-accent: #fc8626;
   --positive-color: #2dcfa1;
   --widget-on-color: var(--positive-color);
-  --toast-success-bg-color: var(--positive-color);
+  --message-success-bg-color: #03ab8c;
   --negative-color: #f04d5d;
-  --toast-error-bg-color: var(--negative-color);
+  --error-color: var(--negative-color);
+  --message-danger-bg-color: var(--error-color);
+  --danger-button-color: var(--negative-color);
   --warning-color: #fc8626;
   --interactive-color: #16b8e0;
-  --toast-info-bg-color: var(--interactive-color);
   --primary-button-color: var(--interactive-color);
   --link-color: var(--interactive-color);
-  --bg-color-light: #f9f9f9;
-  --bg-color-dark: #232323;
   --link-color-reversed: #7feaff;
-  --focus-color:blue-100;
-  --typeahead-selection-color:
-; }
+  --focus-color:blue-100; }
 
 html {
   box-sizing: border-box;

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -6026,6 +6026,27 @@ hr {
 .text-color-reversed-hint {
   color: var(--text-color-hint-reversed) !important; }
 
+.text-color-brand-primary {
+  color: var(--brand-color-primary) !important; }
+
+.text-color-brand-accent {
+  color: var(--brand-color-accent) !important; }
+
+.text-color-positive {
+  color: var(--positive-color) !important; }
+
+.text-color-negative {
+  color: var(--negative-color) !important; }
+
+.text-color-warning {
+  color: var(--warning-color) !important; }
+
+.text-color-interactive {
+  color: var(--interactive-color) !important; }
+
+.text-color-error {
+  color: var(--error-color) !important; }
+
 .text-color-orange {
   color: #fc8626 !important; }
 

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -607,7 +607,7 @@ hr {
   .Checkbox__input:disabled:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23c1c1c1' fill-opacity='1' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"); }
   .Checkbox__input:disabled ~ .Checkbox__label {
-    color: rgba(0, 0, 0, 0.54); }
+    color: var(--text-color-secondary); }
 
 .Checkbox__indicator {
   background-color: #fff;
@@ -881,7 +881,7 @@ hr {
   .Radio__input:disabled:checked:active ~ .Radio__indicator::after {
     background-color: #c1c1c1; }
   .Radio__input:disabled ~ .Radio__label {
-    color: rgba(0, 0, 0, 0.54); }
+    color: var(--text-color-secondary); }
 
 .Radio__indicator {
   background-color: #fff;
@@ -1422,7 +1422,7 @@ hr {
   line-height: 18px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--text-color-secondary);
   margin-top: 7px; }
 
 .FormGroup--small .FormGroup__label {
@@ -1461,7 +1461,7 @@ hr {
   line-height: 18px;
   letter-spacing: 0px;
   font-weight: normal;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--text-color-secondary);
   margin-top: 7px; }
 
 .FormGroup--large .FormGroup__label {
@@ -1515,7 +1515,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-sm .FormGroup__label {
     font-size: 18px;
@@ -1566,7 +1566,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-md .FormGroup__label {
     font-size: 18px;
@@ -1617,7 +1617,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-lg .FormGroup__label {
     font-size: 18px;
@@ -1668,7 +1668,7 @@ hr {
     line-height: 18px;
     letter-spacing: 0px;
     font-weight: normal;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--text-color-secondary);
     margin-top: 7px; }
   .FormGroup--large-xl .FormGroup__label {
     font-size: 18px;
@@ -5996,7 +5996,7 @@ hr {
   color: var(--text-color-primary) !important; }
 
 .text-color-secondary {
-  color: rgba(0, 0, 0, 0.54) !important; }
+  color: var(--text-color-secondary) !important; }
 
 .text-color-hint {
   color: rgba(0, 0, 0, 0.41) !important; }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,11 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@csstools/convert-colors@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
+  integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
+
 "@frctl/fractal@^1.1.0-alpha.0":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@frctl/fractal/-/fractal-1.1.4.tgz#82ead616d44dcc4448261efaf3cf3b071029ca43"
@@ -1627,6 +1632,19 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+autoprefixer@^9.6.1:
+  version "9.8.4"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.4.tgz#736f1012673a70fa3464671d78d41abd54512863"
+  integrity sha512-84aYfXlpUe45lvmS+HoAWKCkirI/sw4JK0/bTeeqgHYco3dcsOn0NqdejISjptsYwNji/21dnkDri9PsYKk89A==
+  dependencies:
+    browserslist "^4.12.0"
+    caniuse-lite "^1.0.30001087"
+    colorette "^1.2.0"
+    normalize-range "^0.1.2"
+    num2fraction "^1.2.2"
+    postcss "^7.0.32"
+    postcss-value-parser "^4.1.0"
+
 aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
@@ -2039,6 +2057,16 @@ browserslist@^4.12.0, browserslist@^4.8.5:
     node-releases "^1.1.53"
     pkg-up "^2.0.0"
 
+browserslist@^4.6.4:
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.12.2.tgz#76653d7e4c57caa8a1a28513e2f4e197dc11a711"
+  integrity sha512-MfZaeYqR8StRZdstAK9hCKDd2StvePCYp5rHzQCPicUjfFliDgmuaBNPHYUTpAywBN8+Wc/d7NYVFkO0aqaBUw==
+  dependencies:
+    caniuse-lite "^1.0.30001088"
+    electron-to-chromium "^1.3.483"
+    escalade "^3.0.1"
+    node-releases "^1.1.58"
+
 bs-recipes@1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/bs-recipes/-/bs-recipes-1.3.4.tgz#0d2d4d48a718c8c044769fdc4f89592dc8b69585"
@@ -2121,6 +2149,11 @@ camelcase@^5.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
+caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001087, caniuse-lite@^1.0.30001088:
+  version "1.0.30001091"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001091.tgz#84908c67b98e02c2a56d4afa51e6458b53fb5321"
+  integrity sha512-ECd8gfBBpv0GKsEYY5052+8PBjExiugDoi3dfkJcxujh2mf7kiuDvb1o27GXlOOGopKiIPYEX8XDPYj7eo3E9w==
+
 caniuse-lite@^1.0.30001043:
   version "1.0.30001084"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001084.tgz#00e471931eaefbeef54f46aa2203914d3c165669"
@@ -2167,7 +2200,7 @@ chalk@^2.0.0:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^2.0.1:
+chalk@^2.0.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -2380,6 +2413,11 @@ color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
+colorette@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.0.tgz#45306add826d196e8c87236ac05d797f25982e63"
+  integrity sha512-soRSroY+OF/8OdA3PTQXwaDJeMc7TfknKKrxeSCencL2a4+Tx5zhxmmv7hdpCjhKBjehzp8+bwe/T68K0hpIjw==
 
 colors@^1.1.2:
   version "1.3.3"
@@ -2631,6 +2669,28 @@ crypto-random-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
   integrity sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=
 
+css-blank-pseudo@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz#dfdefd3254bf8a82027993674ccf35483bfcb3c5"
+  integrity sha512-LHz35Hr83dnFeipc7oqFDmsjHdljj3TQtxGGiNWSOsTLIAubSm4TEz8qCaKFpk7idaQ1GfWscF4E6mgpBysA1w==
+  dependencies:
+    postcss "^7.0.5"
+
+css-has-pseudo@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/css-has-pseudo/-/css-has-pseudo-0.10.0.tgz#3c642ab34ca242c59c41a125df9105841f6966ee"
+  integrity sha512-Z8hnfsZu4o/kt+AuFzeGpLVhFOGO9mluyHBaA2bA8aCGTwah5sT3WV/fTHH8UNZUytOIImuGPrl/prlb4oX4qQ==
+  dependencies:
+    postcss "^7.0.6"
+    postcss-selector-parser "^5.0.0-rc.4"
+
+css-prefers-color-scheme@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz#6f830a2714199d4f0d0d0bb8a27916ed65cff1f4"
+  integrity sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==
+  dependencies:
+    postcss "^7.0.5"
+
 css-select@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
@@ -2643,6 +2703,21 @@ css-select@~1.2.0:
 css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
+cssdb@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/cssdb/-/cssdb-4.4.0.tgz#3bf2f2a68c10f5c6a08abd92378331ee803cddb0"
+  integrity sha512-LsTAR1JPEM9TpGhl/0p3nQecC2LJ0kD8X5YARu1hk/9I1gril5vDtMZyNxcEpxxDj34YNck/ucjuoUd66K03oQ==
+
+cssesc@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-2.0.0.tgz#3b13bd1bb1cb36e1bcb5a4dcd27f54c5dcb35703"
+  integrity sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==
+
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
@@ -2916,6 +2991,11 @@ electron-to-chromium@^1.3.413:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.475.tgz#67688cc82c342f39594a412286e975eda45d8412"
   integrity sha512-vcTeLpPm4+ccoYFXnepvkFt0KujdyrBU19KNEO40Pnkhta6mUi2K0Dn7NmpRcNz7BvysnSqeuIYScP003HWuYg==
 
+electron-to-chromium@^1.3.483:
+  version "1.3.483"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.483.tgz#9269e7cfc1c8e72709824da171cbe47ca5e3ca9e"
+  integrity sha512-+05RF8S9rk8S0G8eBCqBRBaRq7+UN3lDs2DAvnG8SBSgQO3hjy0+qt4CmRk5eiuGbTcaicgXfPmBi31a+BD3lg==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -3046,6 +3126,11 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+escalade@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.0.1.tgz#52568a77443f6927cd0ab9c73129137533c965ed"
+  integrity sha512-DR6NO3h9niOT+MZs7bjxlj2a1k+POu5RN8CLTPX2+i78bRi9eLe7+0zXgUHMnGXWybYcL61E9hGhPKqedy8tQA==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -3439,6 +3524,11 @@ flagged-respawn@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/flagged-respawn/-/flagged-respawn-1.0.1.tgz#e7de6f1279ddd9ca9aac8a5971d618606b3aab41"
   integrity sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==
+
+flatten@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
+  integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -4131,6 +4221,11 @@ indent-string@^2.1.0:
   integrity sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=
   dependencies:
     repeating "^2.0.0"
+
+indexes-of@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
+  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
 
 indexof@0.0.1:
   version "0.0.1"
@@ -4942,6 +5037,11 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash._reinterpolate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
+  integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
+
 lodash.assignin@^4.0.9:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
@@ -5030,6 +5130,21 @@ lodash.reject@^4.4.0:
 lodash.some@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
+lodash.template@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.5.0.tgz#f976195cf3f347d0d5f52483569fe8031ccce8ab"
+  integrity sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
+    lodash.templatesettings "^4.0.0"
+
+lodash.templatesettings@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz#e481310f049d3cf6d47e912ad09313b154f0fb33"
+  integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
+  dependencies:
+    lodash._reinterpolate "^3.0.0"
 
 lodash@^3.10.1, lodash@^3.3.1:
   version "3.10.1"
@@ -5471,7 +5586,7 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.53:
+node-releases@^1.1.53, node-releases@^1.1.58:
   version "1.1.58"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.58.tgz#8ee20eef30fa60e52755fcc0942def5a734fe935"
   integrity sha512-NxBudgVKiRh/2aPWMgPR7bPTX0VPmGx5QBwCtdHitnqFE5/O8DeBXuIMH1nwNnw/aMo6AjOrpsHzfY3UbUJ7yg==
@@ -5550,6 +5665,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+  integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -5592,6 +5712,11 @@ nth-check@~1.0.1:
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
   dependencies:
     boolbase "~1.0.0"
+
+num2fraction@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
+  integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -6116,6 +6241,314 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+postcss-attribute-case-insensitive@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-4.0.2.tgz#d93e46b504589e94ac7277b0463226c68041a880"
+  integrity sha512-clkFxk/9pcdb4Vkn0hAHq3YnxBQ2p0CGD1dy24jN+reBck+EWxMbxSUqN4Yj7t0w8csl87K6p0gxBe1utkJsYA==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-selector-parser "^6.0.2"
+
+postcss-color-functional-notation@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-color-functional-notation/-/postcss-color-functional-notation-2.0.1.tgz#5efd37a88fbabeb00a2966d1e53d98ced93f74e0"
+  integrity sha512-ZBARCypjEDofW4P6IdPVTLhDNXPRn8T2s1zHbZidW6rPaaZvcnCS2soYFIQJrMZSxiePJ2XIYTlcb2ztr/eT2g==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-color-gray@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-color-gray/-/postcss-color-gray-5.0.0.tgz#532a31eb909f8da898ceffe296fdc1f864be8547"
+  integrity sha512-q6BuRnAGKM/ZRpfDascZlIZPjvwsRye7UDNalqVz3s7GDxMtqPY6+Q871liNxsonUw8oC61OG+PSaysYpl1bnw==
+  dependencies:
+    "@csstools/convert-colors" "^1.4.0"
+    postcss "^7.0.5"
+    postcss-values-parser "^2.0.0"
+
+postcss-color-hex-alpha@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-color-hex-alpha/-/postcss-color-hex-alpha-5.0.3.tgz#a8d9ca4c39d497c9661e374b9c51899ef0f87388"
+  integrity sha512-PF4GDel8q3kkreVXKLAGNpHKilXsZ6xuu+mOQMHWHLPNyjiUBOr75sp5ZKJfmv1MCus5/DWUGcK9hm6qHEnXYw==
+  dependencies:
+    postcss "^7.0.14"
+    postcss-values-parser "^2.0.1"
+
+postcss-color-mod-function@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/postcss-color-mod-function/-/postcss-color-mod-function-3.0.3.tgz#816ba145ac11cc3cb6baa905a75a49f903e4d31d"
+  integrity sha512-YP4VG+xufxaVtzV6ZmhEtc+/aTXH3d0JLpnYfxqTvwZPbJhWqp8bSY3nfNzNRFLgB4XSaBA82OE4VjOOKpCdVQ==
+  dependencies:
+    "@csstools/convert-colors" "^1.4.0"
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-color-rebeccapurple@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-4.0.1.tgz#c7a89be872bb74e45b1e3022bfe5748823e6de77"
+  integrity sha512-aAe3OhkS6qJXBbqzvZth2Au4V3KieR5sRQ4ptb2b2O8wgvB3SJBsdG+jsn2BZbbwekDG8nTfcCNKcSfe/lEy8g==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-custom-media@^7.0.8:
+  version "7.0.8"
+  resolved "https://registry.yarnpkg.com/postcss-custom-media/-/postcss-custom-media-7.0.8.tgz#fffd13ffeffad73621be5f387076a28b00294e0c"
+  integrity sha512-c9s5iX0Ge15o00HKbuRuTqNndsJUbaXdiNsksnVH8H4gdc+zbLzr/UasOwNG6CTDpLFekVY4672eWdiiWu2GUg==
+  dependencies:
+    postcss "^7.0.14"
+
+postcss-custom-properties@^8.0.11:
+  version "8.0.11"
+  resolved "https://registry.yarnpkg.com/postcss-custom-properties/-/postcss-custom-properties-8.0.11.tgz#2d61772d6e92f22f5e0d52602df8fae46fa30d97"
+  integrity sha512-nm+o0eLdYqdnJ5abAJeXp4CEU1c1k+eB2yMCvhgzsds/e0umabFrN6HoTy/8Q4K5ilxERdl/JD1LO5ANoYBeMA==
+  dependencies:
+    postcss "^7.0.17"
+    postcss-values-parser "^2.0.1"
+
+postcss-custom-selectors@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/postcss-custom-selectors/-/postcss-custom-selectors-5.1.2.tgz#64858c6eb2ecff2fb41d0b28c9dd7b3db4de7fba"
+  integrity sha512-DSGDhqinCqXqlS4R7KGxL1OSycd1lydugJ1ky4iRXPHdBRiozyMHrdu0H3o7qNOCiZwySZTUI5MV0T8QhCLu+w==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-selector-parser "^5.0.0-rc.3"
+
+postcss-dir-pseudo-class@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-5.0.0.tgz#6e3a4177d0edb3abcc85fdb6fbb1c26dabaeaba2"
+  integrity sha512-3pm4oq8HYWMZePJY+5ANriPs3P07q+LW6FAdTlkFH2XqDdP4HeeJYMOzn0HYLhRSjBO3fhiqSwwU9xEULSrPgw==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-selector-parser "^5.0.0-rc.3"
+
+postcss-double-position-gradients@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-double-position-gradients/-/postcss-double-position-gradients-1.0.0.tgz#fc927d52fddc896cb3a2812ebc5df147e110522e"
+  integrity sha512-G+nV8EnQq25fOI8CH/B6krEohGWnF5+3A6H/+JEpOncu5dCnkS1QQ6+ct3Jkaepw1NGVqqOZH6lqrm244mCftA==
+  dependencies:
+    postcss "^7.0.5"
+    postcss-values-parser "^2.0.0"
+
+postcss-env-function@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-env-function/-/postcss-env-function-2.0.2.tgz#0f3e3d3c57f094a92c2baf4b6241f0b0da5365d7"
+  integrity sha512-rwac4BuZlITeUbiBq60h/xbLzXY43qOsIErngWa4l7Mt+RaSkT7QBjXVGTcBHupykkblHMDrBFh30zchYPaOUw==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-focus-visible@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-focus-visible/-/postcss-focus-visible-4.0.0.tgz#477d107113ade6024b14128317ade2bd1e17046e"
+  integrity sha512-Z5CkWBw0+idJHSV6+Bgf2peDOFf/x4o+vX/pwcNYrWpXFrSfTkQ3JQ1ojrq9yS+upnAlNRHeg8uEwFTgorjI8g==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-focus-within@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-focus-within/-/postcss-focus-within-3.0.0.tgz#763b8788596cee9b874c999201cdde80659ef680"
+  integrity sha512-W0APui8jQeBKbCGZudW37EeMCjDeVxKgiYfIIEo8Bdh5SpB9sxds/Iq8SEuzS0Q4YFOlG7EPFulbbxujpkrV2w==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-font-variant@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-font-variant/-/postcss-font-variant-4.0.0.tgz#71dd3c6c10a0d846c5eda07803439617bbbabacc"
+  integrity sha512-M8BFYKOvCrI2aITzDad7kWuXXTm0YhGdP9Q8HanmN4EF1Hmcgs1KK5rSHylt/lUJe8yLxiSwWAHdScoEiIxztg==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-gap-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-gap-properties/-/postcss-gap-properties-2.0.0.tgz#431c192ab3ed96a3c3d09f2ff615960f902c1715"
+  integrity sha512-QZSqDaMgXCHuHTEzMsS2KfVDOq7ZFiknSpkrPJY6jmxbugUPTuSzs/vuE5I3zv0WAS+3vhrlqhijiprnuQfzmg==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-image-set-function@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-image-set-function/-/postcss-image-set-function-3.0.1.tgz#28920a2f29945bed4c3198d7df6496d410d3f288"
+  integrity sha512-oPTcFFip5LZy8Y/whto91L9xdRHCWEMs3e1MdJxhgt4jy2WYXfhkng59fH5qLXSCPN8k4n94p1Czrfe5IOkKUw==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-initial@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-initial/-/postcss-initial-3.0.2.tgz#f018563694b3c16ae8eaabe3c585ac6319637b2d"
+  integrity sha512-ugA2wKonC0xeNHgirR4D3VWHs2JcU08WAi1KFLVcnb7IN89phID6Qtg2RIctWbnvp1TM2BOmDtX8GGLCKdR8YA==
+  dependencies:
+    lodash.template "^4.5.0"
+    postcss "^7.0.2"
+
+postcss-lab-function@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-lab-function/-/postcss-lab-function-2.0.1.tgz#bb51a6856cd12289ab4ae20db1e3821ef13d7d2e"
+  integrity sha512-whLy1IeZKY+3fYdqQFuDBf8Auw+qFuVnChWjmxm/UhHWqNHZx+B99EwxTvGYmUBqe3Fjxs4L1BoZTJmPu6usVg==
+  dependencies:
+    "@csstools/convert-colors" "^1.4.0"
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-logical@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-logical/-/postcss-logical-3.0.0.tgz#2495d0f8b82e9f262725f75f9401b34e7b45d5b5"
+  integrity sha512-1SUKdJc2vuMOmeItqGuNaC+N8MzBWFWEkAnRnLpFYj1tGGa7NqyVBujfRtgNa2gXR+6RkGUiB2O5Vmh7E2RmiA==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-media-minmax@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-media-minmax/-/postcss-media-minmax-4.0.0.tgz#b75bb6cbc217c8ac49433e12f22048814a4f5ed5"
+  integrity sha512-fo9moya6qyxsjbFAYl97qKO9gyre3qvbMnkOZeZwlsW6XYFsvs2DMGDlchVLfAd8LHPZDxivu/+qW2SMQeTHBw==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-nesting@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-nesting/-/postcss-nesting-7.0.1.tgz#b50ad7b7f0173e5b5e3880c3501344703e04c052"
+  integrity sha512-FrorPb0H3nuVq0Sff7W2rnc3SmIcruVC6YwpcS+k687VxyxO33iE1amna7wHuRVzM8vfiYofXSBHNAZ3QhLvYg==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-overflow-shorthand@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-overflow-shorthand/-/postcss-overflow-shorthand-2.0.0.tgz#31ecf350e9c6f6ddc250a78f0c3e111f32dd4c30"
+  integrity sha512-aK0fHc9CBNx8jbzMYhshZcEv8LtYnBIRYQD5i7w/K/wS9c2+0NSR6B3OVMu5y0hBHYLcMGjfU+dmWYNKH0I85g==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-page-break@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-page-break/-/postcss-page-break-2.0.0.tgz#add52d0e0a528cabe6afee8b46e2abb277df46bf"
+  integrity sha512-tkpTSrLpfLfD9HvgOlJuigLuk39wVTbbd8RKcy8/ugV2bNBUW3xU+AIqyxhDrQr1VUj1RmyJrBn1YWrqUm9zAQ==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-place@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-place/-/postcss-place-4.0.1.tgz#e9f39d33d2dc584e46ee1db45adb77ca9d1dcc62"
+  integrity sha512-Zb6byCSLkgRKLODj/5mQugyuj9bvAAw9LqJJjgwz5cYryGeXfFZfSXoP1UfveccFmeq0b/2xxwcTEVScnqGxBg==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-values-parser "^2.0.0"
+
+postcss-preset-env@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/postcss-preset-env/-/postcss-preset-env-6.7.0.tgz#c34ddacf8f902383b35ad1e030f178f4cdf118a5"
+  integrity sha512-eU4/K5xzSFwUFJ8hTdTQzo2RBLbDVt83QZrAvI07TULOkmyQlnYlpwep+2yIK+K+0KlZO4BvFcleOCCcUtwchg==
+  dependencies:
+    autoprefixer "^9.6.1"
+    browserslist "^4.6.4"
+    caniuse-lite "^1.0.30000981"
+    css-blank-pseudo "^0.1.4"
+    css-has-pseudo "^0.10.0"
+    css-prefers-color-scheme "^3.1.1"
+    cssdb "^4.4.0"
+    postcss "^7.0.17"
+    postcss-attribute-case-insensitive "^4.0.1"
+    postcss-color-functional-notation "^2.0.1"
+    postcss-color-gray "^5.0.0"
+    postcss-color-hex-alpha "^5.0.3"
+    postcss-color-mod-function "^3.0.3"
+    postcss-color-rebeccapurple "^4.0.1"
+    postcss-custom-media "^7.0.8"
+    postcss-custom-properties "^8.0.11"
+    postcss-custom-selectors "^5.1.2"
+    postcss-dir-pseudo-class "^5.0.0"
+    postcss-double-position-gradients "^1.0.0"
+    postcss-env-function "^2.0.2"
+    postcss-focus-visible "^4.0.0"
+    postcss-focus-within "^3.0.0"
+    postcss-font-variant "^4.0.0"
+    postcss-gap-properties "^2.0.0"
+    postcss-image-set-function "^3.0.1"
+    postcss-initial "^3.0.0"
+    postcss-lab-function "^2.0.1"
+    postcss-logical "^3.0.0"
+    postcss-media-minmax "^4.0.0"
+    postcss-nesting "^7.0.0"
+    postcss-overflow-shorthand "^2.0.0"
+    postcss-page-break "^2.0.0"
+    postcss-place "^4.0.1"
+    postcss-pseudo-class-any-link "^6.0.0"
+    postcss-replace-overflow-wrap "^3.0.0"
+    postcss-selector-matches "^4.0.0"
+    postcss-selector-not "^4.0.0"
+
+postcss-pseudo-class-any-link@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-6.0.0.tgz#2ed3eed393b3702879dec4a87032b210daeb04d1"
+  integrity sha512-lgXW9sYJdLqtmw23otOzrtbDXofUdfYzNm4PIpNE322/swES3VU9XlXHeJS46zT2onFO7V1QFdD4Q9LiZj8mew==
+  dependencies:
+    postcss "^7.0.2"
+    postcss-selector-parser "^5.0.0-rc.3"
+
+postcss-replace-overflow-wrap@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-3.0.0.tgz#61b360ffdaedca84c7c918d2b0f0d0ea559ab01c"
+  integrity sha512-2T5hcEHArDT6X9+9dVSPQdo7QHzG4XKclFT8rU5TzJPDN7RIRTbO9c4drUISOVemLj03aezStHCR2AIcr8XLpw==
+  dependencies:
+    postcss "^7.0.2"
+
+postcss-selector-matches@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-matches/-/postcss-selector-matches-4.0.0.tgz#71c8248f917ba2cc93037c9637ee09c64436fcff"
+  integrity sha512-LgsHwQR/EsRYSqlwdGzeaPKVT0Ml7LAT6E75T8W8xLJY62CE4S/l03BWIt3jT8Taq22kXP08s2SfTSzaraoPww==
+  dependencies:
+    balanced-match "^1.0.0"
+    postcss "^7.0.2"
+
+postcss-selector-not@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-not/-/postcss-selector-not-4.0.0.tgz#c68ff7ba96527499e832724a2674d65603b645c0"
+  integrity sha512-W+bkBZRhqJaYN8XAnbbZPLWMvZD1wKTu0UxtFKdhtGjWYmxhkUneoeOhRJKdAE5V7ZTlnbHfCR+6bNwK9e1dTQ==
+  dependencies:
+    balanced-match "^1.0.0"
+    postcss "^7.0.2"
+
+postcss-selector-parser@^5.0.0-rc.3, postcss-selector-parser@^5.0.0-rc.4:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz#249044356697b33b64f1a8f7c80922dddee7195c"
+  integrity sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==
+  dependencies:
+    cssesc "^2.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-selector-parser@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz#934cf799d016c83411859e09dcecade01286ec5c"
+  integrity sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==
+  dependencies:
+    cssesc "^3.0.0"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss-value-parser@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
+  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+
+postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
+  integrity sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==
+  dependencies:
+    flatten "^1.0.2"
+    indexes-of "^1.0.1"
+    uniq "^1.0.1"
+
+postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.32, postcss@^7.0.5, postcss@^7.0.6:
+  version "7.0.32"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.32.tgz#4310d6ee347053da3433db2be492883d62cec59d"
+  integrity sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -7346,6 +7779,13 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
@@ -7629,6 +8069,11 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
 
 unique-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
looks like a lot, but if you ignore the generated css files that we are checking in (of which there are two, both at 6177 lines) there around 350 lines worth of changes in here.


Changes included in this pr:
* Adds a `_theme_config.scss` file which contains a `:root` rule containing all of the themable variable declarations
* Updates the build script to compile two different css files, one with css variables included and one without. (this adds a postcss dependency to the build. post-css is used to strip away the css variables for the non-variable build)
* Updates the react components to use the theme variables
* Updates a few utility classes to use the theme variables
* Updates the phenotypes fractal website to use the themable css file. (This breaks IE11 compatibility)
* Updates the phenotypes fractal website to include a `Theming` guide.
* Updates the README.md to provide instructions on theming.
