### PR TITLE
Bump to version 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminohealth/phenotypes",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Amino's design language and front-end component library",
   "dependencies": {
     "@babel/runtime": "^7.10.2",


### PR DESCRIPTION
Releasing the changes to specificity of spacer rules made [here](https://github.com/aminohealth/phenotypes/pull/100) as a patch.