### PR TITLE
Make focus glow opacity and font family themable

### DIFF
--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -93,6 +93,13 @@
   --focus-color-rgb-values: 127, 234, 255;
   --focus-color: rgb(var(--focus-color-rgb-values));
   --widget-on-color: var(--positive-color);
+  --step-progress-active-glow-opacity: 0.54;
+  --text-input-glow-opacity: 0.41;
+  --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
+  --checkbox-checked-focus-glow-opacity: 0.24;
+  --radio-focus-glow-opacity: var(--text-input-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(--checkbox-checked-focus-glow-opacity);
+  --slider-focus-glow-opacity: 0.7;
   --message-success-bg-color-rgb-values: 3, 171, 140;
   --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
   --message-info-bg-color: var(--brand-color-primary);
@@ -600,7 +607,7 @@ hr {
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity)); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -610,7 +617,7 @@ hr {
     border-color: #232323; }
   .Checkbox__input:checked:focus ~ .Checkbox__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--checkbox-checked-focus-glow-opacity)); }
   .Checkbox__input:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
     background-color: #232323;
@@ -871,7 +878,7 @@ hr {
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity)); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -883,7 +890,7 @@ hr {
       display: block; }
   .Radio__input:checked:focus ~ .Radio__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--radio-checked-focus-glow-opacity)); }
   .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
     background-color: #232323;
     border-color: #232323; }
@@ -1173,7 +1180,7 @@ hr {
     margin-right: 0; }
   .ProgressBar__step::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb-values), 0.54);
+    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb-values), var(--step-progress-active-glow-opacity));
     content: " ";
     height: 100%;
     opacity: 0;
@@ -1224,7 +1231,7 @@ hr {
     background-color: var(--focus-color);
     border-radius: 50%;
     bottom: 7px;
-    box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
     content: '';
     left: 7px;
     opacity: 0;
@@ -1326,7 +1333,7 @@ hr {
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--text-input-glow-opacity));
   outline: 0; }
 
 .TextInput:disabled,

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -64,6 +64,7 @@
   src: url("webfonts/33AD5D_3_0.eot?#iefix") format("embedded-opentype"), url("webfonts/33AD5D_3_0.woff2") format("woff2"), url("webfonts/33AD5D_3_0.woff") format("woff"), url("webfonts/33AD5D_3_0.ttf") format("truetype"); }
 
 :root {
+  --font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --text-color-primary: rgba(0, 0, 0, 0.86);
   --text-color-secondary: rgba(0, 0, 0, 0.54);
   --text-color-hint: rgba(0, 0, 0, 0.41);
@@ -130,7 +131,7 @@ html {
 
 body {
   margin: 0;
-  font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-family);
   font-size: 16px;
   font-weight: normal;
   line-height: 1.49271;

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -25,7 +25,6 @@ For a good chunk of variables there are two variable declarations, with values f
   --text-color-secondary-reversed: rgba(255, 255, 255, 0.76);
   --text-color-hint-reversed: rgba(255, 255, 255, 0.59);
 
-
   --brand-color-primary-rgb-values: 133, 59, 148;
   --brand-color-primary: rgb(var(--brand-color-primary-rgb-values));
   --brand-color-accent-rgb-values: 252, 134, 38;
@@ -40,7 +39,6 @@ For a good chunk of variables there are two variable declarations, with values f
   --interactive-color: rgb(var(--interactive-color-rgb-values));
   --error-color: var(--negative-color);
 
-
   --link-color: var(--interactive-color);
   --link-hover-color-rgb-values: 0, 138, 179;
   --link-hover-color: rgb(var(--link-hover-color-rgb-values));
@@ -54,17 +52,24 @@ For a good chunk of variables there are two variable declarations, with values f
   --focus-color: rgb(var(--focus-color-rgb-values));
   --widget-on-color: var(--positive-color);
 
+  --step-progress-active-glow-opacity: 0.54;
+  --text-input-glow-opacity: 0.41;
+  --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
+  --checkbox-checked-focus-glow-opacity: 0.24;
+  --radio-focus-glow-opacity: var(--text-input-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(
+    --checkbox-checked-focus-glow-opacity
+  );
+  --slider-focus-glow-opacity: 0.7;
 
   --message-success-bg-color-rgb-values: 3, 171, 140;
   --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);
 
-
   --danger-button-color: var(--negative-color);
   --danger-button-focus-color: #ee3548;
   --danger-button-active-color: #ec192e;
-
 
   --primary-button-color: var(--interactive-color);
   --primary-button-focus-color: #14a5c9;
@@ -76,14 +81,13 @@ When overriding a variable you must define the `:root` rule. An example of setti
 
 ```css
 :root {
-    --focus-color-rgb-values: 0, 128, 0
+  --focus-color-rgb-values: 0, 128, 0;
 }
 ```
 
 This will change both the focus color to green as well as apply the correct changes to the box-shadow that is tied to the focus color.
 
 **It is important to remember that CSS variables follow normal CSS cascade rules, so whichever root variable declaration comes last is the one that will be applied.**
-
 
 ### Theming with SASS
 
@@ -125,10 +129,10 @@ Phenotypes also provides you with a mixin called `color-variable` to easily auth
 // that you would like to be themable you can use the `color-variable` mixin
 
 :root {
-    @include color-variable(--primary-button-color, #008000);
-    // this mixin above will be compiled to the following CSS:
-    --primary-button-color-rgb-values: 0, 128, 0;
-    --primary-button-color: rgb(var(--primary-button-color-rgb-values));
+  @include color-variable(--primary-button-color, #008000);
+  // this mixin above will be compiled to the following CSS:
+  --primary-button-color-rgb-values: 0, 128, 0;
+  --primary-button-color: rgb(var(--primary-button-color-rgb-values));
 }
 
 // these compiled variables can then be used throughout the application
@@ -136,11 +140,10 @@ Phenotypes also provides you with a mixin called `color-variable` to easily auth
 // places where the variables are used will be updated.
 
 .PrimaryButton {
-    background-color: var(--primary-button-color);
+  background-color: var(--primary-button-color);
 }
 
 .PrimaryButton:hover {
-    background-color: rgba(var(--primary-button-color-rgb-values), .5);
+  background-color: rgba(var(--primary-button-color-rgb-values), 0.5);
 }
-
 ```

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -18,6 +18,7 @@ For a good chunk of variables there are two variable declarations, with values f
 
 ```css
 :root {
+  --font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
   --text-color-primary: rgba(0, 0, 0, 0.86);
   --text-color-secondary: rgba(0, 0, 0, 0.54);
   --text-color-hint: rgba(0, 0, 0, 0.41);

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -70,7 +70,7 @@
 
   &:focus ~ .Checkbox__indicator {
     border-color: $blue-100;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), $alpha-500);
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity));
   }
 
   &:active ~ .Checkbox__indicator {
@@ -86,7 +86,7 @@
 
   &:checked:focus ~ .Checkbox__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), $alpha-400);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--checkbox-checked-focus-glow-opacity));
   }
 
   &:checked:active ~ .Checkbox__indicator {

--- a/library/components/progress_bar/_progress_bar.scss
+++ b/library/components/progress_bar/_progress_bar.scss
@@ -25,7 +25,10 @@
   &::after {
     background-color: var(--step-progress-active-color);
     box-shadow: 0 0 modular-scale-px(-6) 0
-      rgba(var(--step-progress-active-color-rgb-values), $alpha-600);
+      rgba(
+        var(--step-progress-active-color-rgb-values),
+        var(--step-progress-active-glow-opacity)
+      );
     content: " ";
     height: 100%;
     opacity: 0;

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -75,7 +75,7 @@
 
   &:focus ~ .Radio__indicator {
     border-color: $blue-100;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), $alpha-500);
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity));
   }
 
   &:active ~ .Radio__indicator {
@@ -96,7 +96,7 @@
 
   &:checked:focus ~ .Radio__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), $alpha-400);
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--radio-checked-focus-glow-opacity));
   }
 
   &:checked:active:not(:disabled) ~ .Radio__indicator {

--- a/library/components/slider/_slider.scss
+++ b/library/components/slider/_slider.scss
@@ -54,7 +54,7 @@ $slider-focus-color: $blue-100;
     background-color: var(--focus-color);
     border-radius: 50%;
     bottom: $slider-focus-margin;
-    box-shadow: 0 0 ($slider-focus-size / 2) 0 rgba($slider-focus-color, $alpha-700);
+    box-shadow: 0 0 ($slider-focus-size / 2) 0 rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
     content: '';
     left: $slider-focus-margin;
     opacity: 0;

--- a/library/components/text_input/_text_input.scss
+++ b/library/components/text_input/_text_input.scss
@@ -44,7 +44,7 @@
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), $alpha-500);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--text-input-glow-opacity));
   outline: 0;
 }
 

--- a/styles/_reboot.scss
+++ b/styles/_reboot.scss
@@ -64,7 +64,7 @@ html {
 
 body {
   margin: 0; // 1
-  font-family: $font-family-base;
+  font-family: var(--font-family);
   font-size: $font-size-base;
   font-weight: $font-weight-base;
   line-height: $line-height-base;

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -6,6 +6,11 @@
 // ------------------------------
 :root {
   // base variable set
+  // interpolation removes quotes from strings
+  // we can use inspect to preserve strings
+  // See Heads up section on the following page:
+  // https://sass-lang.com/documentation/style-rules/declarations#custom-properties
+  --font-family: #{inspect($font-family-base)};
   --text-color-primary: #{$text-color-primary};
   --text-color-secondary: #{$text-color-secondary};
   --text-color-hint: #{$text-color-hint};

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -28,6 +28,15 @@
   @include color-variable(--focus-color, $blue-100);
   --widget-on-color: var(--positive-color);
 
+  // glow opacities
+  --step-progress-active-glow-opacity: #{$alpha-600};
+  --text-input-glow-opacity: #{$alpha-500};
+  --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
+  --checkbox-checked-focus-glow-opacity: #{$alpha-400};
+  --radio-focus-glow-opacity: var(--text-input-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(--checkbox-checked-focus-glow-opacity);
+  --slider-focus-glow-opacity: #{$alpha-700};
+
   @include color-variable(--message-success-bg-color, $green-300);
   --message-info-bg-color: var(--brand-color-primary);
   --message-danger-bg-color: var(--error-color);

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -93,6 +93,13 @@
   --focus-color-rgb-values: 127, 234, 255;
   --focus-color: rgb(var(--focus-color-rgb-values));
   --widget-on-color: var(--positive-color);
+  --step-progress-active-glow-opacity: 0.54;
+  --text-input-glow-opacity: 0.41;
+  --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
+  --checkbox-checked-focus-glow-opacity: 0.24;
+  --radio-focus-glow-opacity: var(--text-input-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(--checkbox-checked-focus-glow-opacity);
+  --slider-focus-glow-opacity: 0.7;
   --message-success-bg-color-rgb-values: 3, 171, 140;
   --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
   --message-info-bg-color: var(--brand-color-primary);
@@ -600,7 +607,7 @@ hr {
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity)); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -610,7 +617,7 @@ hr {
     border-color: #232323; }
   .Checkbox__input:checked:focus ~ .Checkbox__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--checkbox-checked-focus-glow-opacity)); }
   .Checkbox__input:checked:active ~ .Checkbox__indicator {
     background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='%23fff' fill-opacity='0.54' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A");
     background-color: #232323;
@@ -871,7 +878,7 @@ hr {
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
     border-color: #7feaff;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41); }
+    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity)); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
     border-color: #c1c1c1; }
@@ -883,7 +890,7 @@ hr {
       display: block; }
   .Radio__input:checked:focus ~ .Radio__indicator {
     border-color: #232323;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), 0.24); }
+    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--radio-checked-focus-glow-opacity)); }
   .Radio__input:checked:active:not(:disabled) ~ .Radio__indicator {
     background-color: #232323;
     border-color: #232323; }
@@ -1173,7 +1180,7 @@ hr {
     margin-right: 0; }
   .ProgressBar__step::after {
     background-color: var(--step-progress-active-color);
-    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb-values), 0.54);
+    box-shadow: 0 0 7px 0 rgba(var(--step-progress-active-color-rgb-values), var(--step-progress-active-glow-opacity));
     content: " ";
     height: 100%;
     opacity: 0;
@@ -1224,7 +1231,7 @@ hr {
     background-color: var(--focus-color);
     border-radius: 50%;
     bottom: 7px;
-    box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
+    box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
     content: '';
     left: 7px;
     opacity: 0;
@@ -1326,7 +1333,7 @@ hr {
 
 .TextInput:focus {
   border-color: var(--focus-color);
-  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), 0.41);
+  box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--text-input-glow-opacity));
   outline: 0; }
 
 .TextInput:disabled,

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -64,6 +64,7 @@
   src: url("webfonts/33AD5D_3_0.eot?#iefix") format("embedded-opentype"), url("webfonts/33AD5D_3_0.woff2") format("woff2"), url("webfonts/33AD5D_3_0.woff") format("woff"), url("webfonts/33AD5D_3_0.ttf") format("truetype"); }
 
 :root {
+  --font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --text-color-primary: rgba(0, 0, 0, 0.86);
   --text-color-secondary: rgba(0, 0, 0, 0.54);
   --text-color-hint: rgba(0, 0, 0, 0.41);
@@ -130,7 +131,7 @@ html {
 
 body {
   margin: 0;
-  font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-family);
   font-size: 16px;
   font-weight: normal;
   line-height: 1.49271;


### PR DESCRIPTION
Adds a few extra variables to make focus glow opacities themable. This will be helpful especially when we want to disable the glow for certain themes. The variables are listed below:

* `--step-progress-active-glow-opacity`
* `--text-input-glow-opacity`
* `--checkbox-focus-glow-opacity`
* `--checkbox-checked-focus-glow-opacity`
* `--radio-focus-glow-opacity`
* `--radio-checked-focus-glow-opacity`
* `--slider-focus-glow-opacity`

Also adds a `--font-family` variable to make font family themable.