### PR TITLE
Update form elements to have themable borders + add sourcemaps

### DIFF
--- a/configs/rollup.phenotypes-library.config.js
+++ b/configs/rollup.phenotypes-library.config.js
@@ -42,6 +42,7 @@ export default [
       // for modern bundlers like webpack 2+ and rollup
       // output esm format
       format: 'esm',
+      sourcemap: true,
     },
   },
   {
@@ -50,6 +51,7 @@ export default [
       file: path.resolve(WORKSPACE_ROOT, packageJSON.main),
       // output commonjs format for older workflows
       format: 'cjs',
+      sourcemap: true,
     },
   },
 ];

--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -99,7 +99,9 @@
   --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
   --checkbox-checked-focus-glow-opacity: 0.24;
   --radio-focus-glow-opacity: var(--text-input-glow-opacity);
-  --radio-checked-focus-glow-opacity: var(--checkbox-checked-focus-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(
+    --checkbox-checked-focus-glow-opacity
+  );
   --slider-focus-glow-opacity: 0.7;
   --message-success-bg-color-rgb-values: 3, 171, 140;
   --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
@@ -607,7 +609,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
-    border-color: #7feaff;
+    border-color: var(--focus-color);
     box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity)); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
@@ -878,7 +880,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
-    border-color: #7feaff;
+    border-color: var(--focus-color);
     box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity)); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
@@ -1233,13 +1235,13 @@ hr {
     border-radius: 50%;
     bottom: 7px;
     box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
-    content: '';
+    content: "";
     left: 7px;
     opacity: 0;
     position: absolute;
     right: 7px;
     top: 7px;
-    transition: opacity .15s linear; }
+    transition: opacity 0.15s linear; }
 
 .Slider--is-disabled {
   cursor: not-allowed;

--- a/library/components/checkbox/_checkbox.scss
+++ b/library/components/checkbox/_checkbox.scss
@@ -1,12 +1,12 @@
 // scss-lint:disable SelectorFormat ElsePlacement StringQuotes
 
-@import '../../../styles/lib/str-replace';
+@import "../../../styles/lib/str-replace";
 
 // Checkbox based on Bootstrap's "custom control"
 // https://github.com/twbs/bootstrap/blob/v4-dev/scss/_custom-forms.scss
 
-@mixin checkbox-sizer($size: 'medium') {
-  @if $size == 'small' {
+@mixin checkbox-sizer($size: "medium") {
+  @if $size == "small" {
     $width: modular-scale-px(-1);
 
     @include text-1;
@@ -19,9 +19,7 @@
       top: 1px;
       width: $width;
     }
-  }
-
-  @else if $size == 'medium' {
+  } @else if $size == "medium" {
     $width: modular-scale-px(0);
 
     @include text-2;
@@ -34,9 +32,7 @@
       top: 1px;
       width: $width;
     }
-  }
-
-  @else if $size == 'large' {
+  } @else if $size == "large" {
     $width: modular-scale-px(2);
 
     @include text-4;
@@ -53,7 +49,11 @@
 }
 
 @mixin checkbox-icon($fill: $white, $fill-opacity: 1) {
-  background-image: str-replace(url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='#{$fill}' fill-opacity='#{$fill-opacity}' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"), '#', '%23');
+  background-image: str-replace(
+    url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 9'%3E%3Cpolygon fill='#{$fill}' fill-opacity='#{$fill-opacity}' points='3.5 5.45 1.5 3.45 0 4.95 3.5 8.45 10 1.95 8.5 .45'/%3E%3C/svg%3E%0A"),
+    "#",
+    "%23"
+  );
 }
 
 .Checkbox {
@@ -69,8 +69,9 @@
   z-index: -1;
 
   &:focus ~ .Checkbox__indicator {
-    border-color: $blue-100;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity));
+    border-color: var(--focus-color);
+    box-shadow: 0 0 11px
+      rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity));
   }
 
   &:active ~ .Checkbox__indicator {
@@ -86,7 +87,11 @@
 
   &:checked:focus ~ .Checkbox__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--checkbox-checked-focus-glow-opacity));
+    box-shadow: 0 0 0 2px
+      rgba(
+        var(--interactive-color-rgb-values),
+        var(--checkbox-checked-focus-glow-opacity)
+      );
   }
 
   &:checked:active ~ .Checkbox__indicator {
@@ -132,12 +137,22 @@
     @include media-breakpoint-up($breakpoint) {
       $suffix: breakpoint-suffix($breakpoint, $grid-breakpoints);
 
-      .Checkbox--medium#{$suffix} { @include checkbox-sizer; }
-      .Checkbox--small#{$suffix} { @include checkbox-sizer('small'); }
-      .Checkbox--large#{$suffix} { @include checkbox-sizer('large'); }
+      .Checkbox--medium#{$suffix} {
+        @include checkbox-sizer;
+      }
+      .Checkbox--small#{$suffix} {
+        @include checkbox-sizer("small");
+      }
+      .Checkbox--large#{$suffix} {
+        @include checkbox-sizer("large");
+      }
     }
   }
 } @else {
-  .Checkbox--small { @include checkbox-sizer('small'); }
-  .Checkbox--large { @include checkbox-sizer('large'); }
+  .Checkbox--small {
+    @include checkbox-sizer("small");
+  }
+  .Checkbox--large {
+    @include checkbox-sizer("large");
+  }
 }

--- a/library/components/radio/_radio.scss
+++ b/library/components/radio/_radio.scss
@@ -74,8 +74,9 @@
   z-index: -1;
 
   &:focus ~ .Radio__indicator {
-    border-color: $blue-100;
-    box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity));
+    border-color: var(--focus-color);
+    box-shadow: 0 0 11px
+      rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity));
   }
 
   &:active ~ .Radio__indicator {
@@ -96,7 +97,11 @@
 
   &:checked:focus ~ .Radio__indicator {
     border-color: $gray-800;
-    box-shadow: 0 0 0 2px rgba(var(--interactive-color-rgb-values), var(--radio-checked-focus-glow-opacity));
+    box-shadow: 0 0 0 2px
+      rgba(
+        var(--interactive-color-rgb-values),
+        var(--radio-checked-focus-glow-opacity)
+      );
   }
 
   &:checked:active:not(:disabled) ~ .Radio__indicator {

--- a/library/components/slider/_slider.scss
+++ b/library/components/slider/_slider.scss
@@ -1,10 +1,11 @@
 $slider-handle-size: modular-scale-px(3);
 $slider-track-height: 3px;
-$slider-track-offset: floor(($slider-handle-size / 2) - ($slider-track-height / 2));
+$slider-track-offset: floor(
+  ($slider-handle-size / 2) - ($slider-track-height / 2)
+);
 $slider-track-border-radius: $slider-track-height / 2;
 $slider-focus-margin: modular-scale-px(-6);
 $slider-focus-size: $slider-handle-size - ($slider-focus-margin * 2);
-$slider-focus-color: $blue-100;
 
 .Slider {
   cursor: pointer;
@@ -54,14 +55,15 @@ $slider-focus-color: $blue-100;
     background-color: var(--focus-color);
     border-radius: 50%;
     bottom: $slider-focus-margin;
-    box-shadow: 0 0 ($slider-focus-size / 2) 0 rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
-    content: '';
+    box-shadow: 0 0 ($slider-focus-size / 2) 0
+      rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
+    content: "";
     left: $slider-focus-margin;
     opacity: 0;
     position: absolute;
     right: $slider-focus-margin;
     top: $slider-focus-margin;
-    transition: opacity .15s linear;
+    transition: opacity 0.15s linear;
   }
 }
 
@@ -76,7 +78,11 @@ $slider-focus-color: $blue-100;
   }
 }
 
-@mixin slider-color($fill-color, $track-color: rgba($black, $alpha-300), $handle-color: $white) {
+@mixin slider-color(
+  $fill-color,
+  $track-color: rgba($black, $alpha-300),
+  $handle-color: $white
+) {
   .Slider__track-line {
     background-color: $track-color;
   }

--- a/styles/_theme_config.scss
+++ b/styles/_theme_config.scss
@@ -39,7 +39,9 @@
   --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
   --checkbox-checked-focus-glow-opacity: #{$alpha-400};
   --radio-focus-glow-opacity: var(--text-input-glow-opacity);
-  --radio-checked-focus-glow-opacity: var(--checkbox-checked-focus-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(
+    --checkbox-checked-focus-glow-opacity
+  );
   --slider-focus-glow-opacity: #{$alpha-700};
 
   @include color-variable(--message-success-bg-color, $green-300);

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -559,7 +559,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
-    border-color: #7feaff;
+    border-color: rgb(127, 234, 255);
     box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
@@ -833,7 +833,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
-    border-color: #7feaff;
+    border-color: rgb(127, 234, 255);
     box-shadow: 0 0 11px rgba(127, 234, 255, 0.41); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
@@ -1191,13 +1191,13 @@ hr {
     border-radius: 50%;
     bottom: 7px;
     box-shadow: 0 0 5px 0 rgba(127, 234, 255, 0.7);
-    content: '';
+    content: "";
     left: 7px;
     opacity: 0;
     position: absolute;
     right: 7px;
     top: 7px;
-    transition: opacity .15s linear; }
+    transition: opacity 0.15s linear; }
 
 .Slider--is-disabled {
   cursor: not-allowed;

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -99,7 +99,9 @@
   --checkbox-focus-glow-opacity: var(--text-input-glow-opacity);
   --checkbox-checked-focus-glow-opacity: 0.24;
   --radio-focus-glow-opacity: var(--text-input-glow-opacity);
-  --radio-checked-focus-glow-opacity: var(--checkbox-checked-focus-glow-opacity);
+  --radio-checked-focus-glow-opacity: var(
+    --checkbox-checked-focus-glow-opacity
+  );
   --slider-focus-glow-opacity: 0.7;
   --message-success-bg-color-rgb-values: 3, 171, 140;
   --message-success-bg-color: rgb(var(--message-success-bg-color-rgb-values));
@@ -607,7 +609,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Checkbox__input:focus ~ .Checkbox__indicator {
-    border-color: #7feaff;
+    border-color: var(--focus-color);
     box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--checkbox-focus-glow-opacity)); }
   .Checkbox__input:active ~ .Checkbox__indicator {
     background-color: #f9f9f9;
@@ -878,7 +880,7 @@ hr {
   position: absolute;
   z-index: -1; }
   .Radio__input:focus ~ .Radio__indicator {
-    border-color: #7feaff;
+    border-color: var(--focus-color);
     box-shadow: 0 0 11px rgba(var(--focus-color-rgb-values), var(--radio-focus-glow-opacity)); }
   .Radio__input:active ~ .Radio__indicator {
     background-color: #f9f9f9;
@@ -1233,13 +1235,13 @@ hr {
     border-radius: 50%;
     bottom: 7px;
     box-shadow: 0 0 5px 0 rgba(var(--focus-color-rgb-values), var(--slider-focus-glow-opacity));
-    content: '';
+    content: "";
     left: 7px;
     opacity: 0;
     position: absolute;
     right: 7px;
     top: 7px;
-    transition: opacity .15s linear; }
+    transition: opacity 0.15s linear; }
 
 .Slider--is-disabled {
   cursor: not-allowed;


### PR DESCRIPTION
This pr does two things:
When we added theming support, a few form element border-color declarations were missed in the conversion to use theming variables. This fixes that bug.

I also added source maps for the compiled outputs since it was as simple as adding a flag and will help with debugging the compiled output if the need arises.

Prettier also formatted a few of these files so the changes look a bit bigger than they actually are.