### PR TITLE
Reformat all markdown files with prettier

### DIFF
--- a/guides/01-index.md
+++ b/guides/01-index.md
@@ -5,7 +5,7 @@ status: draft
 
 Welcome to Phenotypes—Amino's design system. Phenotypes is a repository of principles and modules that we use to design and build our products. It's a central source of truth that facilitates clear communication and efficient workflows for designers and developers.
 
-The design system is built from the foundation up, starting with abstract principles—like brand attributes and modular scale—and applying them consistently to everything from our color palette to complex interactive components. 
+The design system is built from the foundation up, starting with abstract principles—like brand attributes and modular scale—and applying them consistently to everything from our color palette to complex interactive components.
 
 Phenotypes often draws inspiration from and even borrows ideas and syntax from ambitious projects like [Google's Material Design](https://material.io/guidelines/) and [Bootstrap](https://v4-alpha.getbootstrap.com/getting-started/introduction/). Many talented people have put an incredible amount of effort into these and other projects. Whenever we borrow, we make a note of it for attribution and further reading.
 
@@ -17,12 +17,12 @@ By its nature, Phenotypes is and always will be a work in progress. Use it in go
 
 Phenotypes treats the following topics as first-class concerns:
 
-* Alignment with Amino's brand attributes (see below)
-* Aesthetics and principles of good design (e.g. consistency)
-* Usability and accessibility
-* Technology considerations like devices and web browsers
-* Longevity and maintainability
-* Balancing philosophical purity with implementation pragmatism
+- Alignment with Amino's brand attributes (see below)
+- Aesthetics and principles of good design (e.g. consistency)
+- Usability and accessibility
+- Technology considerations like devices and web browsers
+- Longevity and maintainability
+- Balancing philosophical purity with implementation pragmatism
 
 ---
 
@@ -30,10 +30,10 @@ Phenotypes treats the following topics as first-class concerns:
 
 Amino's brand attributes are:
 
-* **Confident**
-* **Optimistic**
-* **Clear**
-* **Clever**  ← this replaces *Inventive* and *Human* and is still being discussed...
+- **Confident**
+- **Optimistic**
+- **Clear**
+- **Clever** ← this replaces _Inventive_ and _Human_ and is still being discussed...
 
 Although they can seem abstract, the brand attributes affect nearly every aspect of the design system. For example, the word “confident” guides us to set headlines in bold type and "optimistic" suggests lively, colorful graphics rather than muted pastels. “Clear” guides us to simplify concepts, craft tight copy, and use a font that's highly legible.
 
@@ -45,7 +45,7 @@ The core elements of our branding are detailed in the foundational sections that
 
 ## Quick start
 
-* [Amino logo files](https://www.dropbox.com/s/fq5981ebiduww03/amino%20logo%2021.zip?dl=1) (17MB zip file) and [guidelines]({{ path '/docs/logo' }})
-* [Phenotypes Sketch template and Craft Library](https://www.dropbox.com/sh/5ax1ihpnkezixu1/AAAAkGffs9vjeuf16yU_m8nva?dl=0)
-* [Assets](https://www.dropbox.com/sh/y7868ecf5jwbc0s/AABHlbgbeB0ICIF9ptmtxRs1a?dl=0) (icons, fonts, colors palettes)
-* [GitHub repo](https://github.com/aminohealth/phenotypes)
+- [Amino logo files](https://www.dropbox.com/s/fq5981ebiduww03/amino%20logo%2021.zip?dl=1) (17MB zip file) and [guidelines]({{ path '/docs/logo' }})
+- [Phenotypes Sketch template and Craft Library](https://www.dropbox.com/sh/5ax1ihpnkezixu1/AAAAkGffs9vjeuf16yU_m8nva?dl=0)
+- [Assets](https://www.dropbox.com/sh/y7868ecf5jwbc0s/AABHlbgbeB0ICIF9ptmtxRs1a?dl=0) (icons, fonts, colors palettes)
+- [GitHub repo](https://github.com/aminohealth/phenotypes)

--- a/guides/02-modular-scale.md
+++ b/guides/02-modular-scale.md
@@ -4,13 +4,13 @@ status: stable
 
 > "A modular scale, like a musical scale, is a prearranged set of harmonious proportions." <br>—Robert Bringhurst
 
-A *modular scale* is a set of numbers that are proportionally related to each other. Basically, you pick a base number and a multiplier to create a sequence. Then you use that sequence as much as possible to make design decisions. If you need to choose a font size or decide how much whitespace to use in a layout, let the modular scale be your guide. [Learn more about modular scales](https://alistapart.com/article/more-meaningful-typography).
+A _modular scale_ is a set of numbers that are proportionally related to each other. Basically, you pick a base number and a multiplier to create a sequence. Then you use that sequence as much as possible to make design decisions. If you need to choose a font size or decide how much whitespace to use in a layout, let the modular scale be your guide. [Learn more about modular scales](https://alistapart.com/article/more-meaningful-typography).
 
-For some reason, there seems to be a bit of mysticism surrounding modular scales. You don't have to look very hard to find flimflam about music theory, golden ratios, and other bits of magic that will make your designs “resonate” (a word borrowed from the article linked above). Take that stuff with a [grain of salt](http://www.lhup.edu/~dsimanek/pseudo/fibonacc.htm), but don't dismiss the power of having your design decisions rooted in some basic logic. 
+For some reason, there seems to be a bit of mysticism surrounding modular scales. You don't have to look very hard to find flimflam about music theory, golden ratios, and other bits of magic that will make your designs “resonate” (a word borrowed from the article linked above). Take that stuff with a [grain of salt](http://www.lhup.edu/~dsimanek/pseudo/fibonacc.htm), but don't dismiss the power of having your design decisions rooted in some basic logic.
 
 Once you get used to working with the modular scale, it begins to feel like the kind of liberating design constraint that facilitates creativity. Instead of arbitrarily nudging an element around one pixel (or ten pixels) at a time looking for that perfect spot, use a number from the modular scale. Chances are, one will feel right. Plus, your developer friends will love you forever.
 
-Phenotypes uses a modular scale to create harmony and consistency throughout the design system. It's the basis for our typography, spacing, and even color system (for the grays, at least). The mechanics of the modular scale are explained below so that you can use it along with Phenotypes components to maintain that harmony and consistency in the products and assets you create. 
+Phenotypes uses a modular scale to create harmony and consistency throughout the design system. It's the basis for our typography, spacing, and even color system (for the grays, at least). The mechanics of the modular scale are explained below so that you can use it along with Phenotypes components to maintain that harmony and consistency in the products and assets you create.
 
 Here's our modular scale:
 
@@ -24,15 +24,16 @@ The first step in creating a modular scale is to pick a base number. Ours is 16p
 
 This is the multiplier value that's used to create the rest of the numbers in the modular scale. Multiply or divide any number in the modular scale by this proportion, and you have another valid number (it's usually best to round to the nearest pixel). Multiply or divide the proportion by itself and you have another valid ratio. That's all there is to it.
 
-Picking a good proportion turns out to be a pretty interesting exercise. One of the goals of a modular scale is to constrain the number of available options—reducing the need for designers to nudge and for developers to measure. A larger proportion like 1.5 would constrain the options, but it would also leave bigger gaps in a range that's especially useful for UI design. For example, you'd have no font sizes between 11px and 16px, and you would find yourself having to make a lot more one-off exceptions for design sanity. 
+Picking a good proportion turns out to be a pretty interesting exercise. One of the goals of a modular scale is to constrain the number of available options—reducing the need for designers to nudge and for developers to measure. A larger proportion like 1.5 would constrain the options, but it would also leave bigger gaps in a range that's especially useful for UI design. For example, you'd have no font sizes between 11px and 16px, and you would find yourself having to make a lot more one-off exceptions for design sanity.
 
-The smaller 8/7 proportion provides more granularity, which is both a strength and a weakness. It should be able to cover  more use cases with fewer one-off exceptions, but it creates too many small values too close together: 5, 6, 7, 8, and 9 are all included 😬. 
+The smaller 8/7 proportion provides more granularity, which is both a strength and a weakness. It should be able to cover more use cases with fewer one-off exceptions, but it creates too many small values too close together: 5, 6, 7, 8, and 9 are all included 😬.
 
-Given the fundamental tradeoff between granularity and constraint, we go with granularity. If our modular scale requires designers to be making a lot of exceptions, then its utility is greatly diminished, because those exceptions are likely to be made in an arbitrary way and would require careful measurement and one-off styles to implement. On the other hand, if its excessive granularity can be managed by designers creating their own constraints within the constructs of the modular scale, then it's still a very useful tool. 
+Given the fundamental tradeoff between granularity and constraint, we go with granularity. If our modular scale requires designers to be making a lot of exceptions, then its utility is greatly diminished, because those exceptions are likely to be made in an arbitrary way and would require careful measurement and one-off styles to implement. On the other hand, if its excessive granularity can be managed by designers creating their own constraints within the constructs of the modular scale, then it's still a very useful tool.
 
 Here's what that means. Try limiting yourself to using every other or every third number, and when you need to make an exception, go ahead and use one of the numbers in between. Phenotypes typography is based primarily on 3-step jumps (highlighted in purple above), but it uses interstitial increments as needed to create balanced, pleasing aesthetics at smaller sizes.
 
 ![Modular scale sample](/img/guides/modular-scale-spacing-example.png)
+
 <p class="caption">Every decision in this composition was made using numbers from the modular scale (including the margins).</p>
 
 ### Things to keep in mind
@@ -47,48 +48,48 @@ Remember that the modular scale is just a tool. It can save you a lot of time an
 
 Here's a handy table that you can copy and paste or get tattooed on your arm:
 
-Exponent | Ratio | Number
--------- | ----- | ------
--8 |  0.344 | 5
--7 |  0.393 | 6
--6 |  0.449 | 7
--5 |  0.513 | 8
--4 |  0.586 | 9
--3 |  0.67 | 11
--2 |  0.766 | 12
--1 |  0.875 | 14
-**0** |  **1**  | **16**
-1 |  1.143 | 18
-2 |  1.306 | 21
-3 |  1.493 | 24
-4 |  1.706 | 27
-5 |  1.95 | 31
-6 |  2.228 | 36
-7 |  2.546 | 41
-8 |  2.91 | 47
-9 |  3.326 | 53
-10 |  3.801 | 61
-11 |  4.344 | 70
-12 |  4.965 | 79
-13 |  5.674 | 91
-14 |  6.485 | 104
-15 |  7.411 | 119
-16 |  8.47 | 136
-17 |  9.68 | 155
-18 |  11.063 | 177
-19 |  12.643 | 202
-20 |  14.449 | 231
-21 |  16.513 | 264
-22 |  18.872 | 302
-23 |  21.568 | 345
-24 |  24.649 | 394
-25 |  28.171 | 451
-26 |  32.195 | 515
-27 |  36.794 | 589
-28 |  42.051 | 673
-29 |  48.058 | 769
-30 |  54.924 | 879
-31 |  62.77 | 1004
-32 |  71.737 | 1148
-33 |  81.985 | 1312
-34 |  93.697 | 1499
+| Exponent | Ratio  | Number |
+| -------- | ------ | ------ |
+| -8       | 0.344  | 5      |
+| -7       | 0.393  | 6      |
+| -6       | 0.449  | 7      |
+| -5       | 0.513  | 8      |
+| -4       | 0.586  | 9      |
+| -3       | 0.67   | 11     |
+| -2       | 0.766  | 12     |
+| -1       | 0.875  | 14     |
+| **0**    | **1**  | **16** |
+| 1        | 1.143  | 18     |
+| 2        | 1.306  | 21     |
+| 3        | 1.493  | 24     |
+| 4        | 1.706  | 27     |
+| 5        | 1.95   | 31     |
+| 6        | 2.228  | 36     |
+| 7        | 2.546  | 41     |
+| 8        | 2.91   | 47     |
+| 9        | 3.326  | 53     |
+| 10       | 3.801  | 61     |
+| 11       | 4.344  | 70     |
+| 12       | 4.965  | 79     |
+| 13       | 5.674  | 91     |
+| 14       | 6.485  | 104    |
+| 15       | 7.411  | 119    |
+| 16       | 8.47   | 136    |
+| 17       | 9.68   | 155    |
+| 18       | 11.063 | 177    |
+| 19       | 12.643 | 202    |
+| 20       | 14.449 | 231    |
+| 21       | 16.513 | 264    |
+| 22       | 18.872 | 302    |
+| 23       | 21.568 | 345    |
+| 24       | 24.649 | 394    |
+| 25       | 28.171 | 451    |
+| 26       | 32.195 | 515    |
+| 27       | 36.794 | 589    |
+| 28       | 42.051 | 673    |
+| 29       | 48.058 | 769    |
+| 30       | 54.924 | 879    |
+| 31       | 62.77  | 1004   |
+| 32       | 71.737 | 1148   |
+| 33       | 81.985 | 1312   |
+| 34       | 93.697 | 1499   |

--- a/guides/03-typography.md
+++ b/guides/03-typography.md
@@ -26,19 +26,19 @@ There's no single line height that works well for all font sizes. As type gets b
 
 Phenotypes prescribes **three line heights that depend on font size.** They are selected from the modular scale:
 
-Font size | Modular scale steps | Line height
----|---|---
-**< 12** | **3 steps** | **1.493**
-12 | 3 steps | 1.493
-14 | 3 steps | 1.493
-16 | 3 steps | 1.493
-18 | 3 steps | 1.493
-21 | 3 steps | 1.493
-**24** | **2 steps** | **1.306**
-36 | 2 steps | 1.306
-**53** | **1 step** | **1.143**
-70 | 1 step | 1.143
-> 70 | 1 step | 1.143
+| Font size | Modular scale steps | Line height |
+| --------- | ------------------- | ----------- |
+| **< 12**  | **3 steps**         | **1.493**   |
+| 12        | 3 steps             | 1.493       |
+| 14        | 3 steps             | 1.493       |
+| 16        | 3 steps             | 1.493       |
+| 18        | 3 steps             | 1.493       |
+| 21        | 3 steps             | 1.493       |
+| **24**    | **2 steps**         | **1.306**   |
+| 36        | 2 steps             | 1.306       |
+| **53**    | **1 step**          | **1.143**   |
+| 70        | 1 step              | 1.143       |
+| > 70      | 1 step              | 1.143       |
 
 As always, use your best judgement. If you're designing an event poster with huge type, you might find yourself needing to use a line height of 1.0 or even tighter to achieve the right look. For product UI, presentations, and other general uses, the line heights above should serve you well.
 
@@ -50,7 +50,7 @@ On small mobile screens, line length is usually modulated by choosing font sizes
 
 ### Letter spacing
 
-Generally, letter spacing isn't required for small and medium type*. Type **larger than 50px** starts to feel too loose horizontally and should be given subtle and progressive negative letter spacing according to this formula: 
+Generally, letter spacing isn't required for small and medium type\*. Type **larger than 50px** starts to feel too loose horizontally and should be given subtle and progressive negative letter spacing according to this formula:
 
 ```
 letter_spacing = -0.6 * [floor(font_size * 0.02)^2]
@@ -85,14 +85,14 @@ These opacities of black match the brand gray palette when set against a white b
 Text color contrast is a very important accessibility concern. Not everyone can read light gray type on white—a style designers tend to favor. You need to **consider color contrast** whenever you're reducing the prominence of text or setting text in some color against a background pattern, image, or color (including black or white). The [Web Content Accessibility Guidelines (WCAG) 2.0](http://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast) says the following:
 
 > **4.3 Contrast (Minimum):** The visual presentation of [text](http://www.w3.org/TR/WCAG20/#textdef) and [images of text](http://www.w3.org/TR/WCAG20/#images-of-textdef) has a [contrast ratio](http://www.w3.org/TR/WCAG20/#contrast-ratiodef) of **at least 4.5:1,** except for the following: (Level AA)
-> 
-> * **Large Text:** [Large-scale](http://www.w3.org/TR/WCAG20/#larger-scaledef) text and images of large-scale text have a contrast ratio of **at least 3:1**;
-> * **Incidental:** Text or images of text that are part of an inactive [user interface component](> http://www.w3.org/TR/WCAG20/#user-interface-componentdef), that are [pure decoration](http://> www.w3.org/TR/WCAG20/#puredecdef), that are not visible to anyone, or that are part of a picture that contains significant other visual content, have **no contrast requirement**.
-> * **Logotypes:** Text that is part of a logo or brand name has no minimum contrast requirement.
+>
+> - **Large Text:** [Large-scale](http://www.w3.org/TR/WCAG20/#larger-scaledef) text and images of large-scale text have a contrast ratio of **at least 3:1**;
+> - **Incidental:** Text or images of text that are part of an inactive [user interface component](> http://www.w3.org/TR/WCAG20/#user-interface-componentdef), that are [pure decoration](http://> www.w3.org/TR/WCAG20/#puredecdef), that are not visible to anyone, or that are part of a picture that contains significant other visual content, have **no contrast requirement**.
+> - **Logotypes:** Text that is part of a logo or brand name has no minimum contrast requirement.
 
 Long story short: try to maintain a **minimum contrast ratio of 4.5**. A contrast ratio of **7 or higher is ideal**, as that's the cutoff for Level AAA accessibility (AAA is the highest level of accessibility compliance, but it's not [expected](http://www.w3.org/TR/UNDERSTANDING-WCAG20/conformance.html) for any project to adhere to that level 100% of the time).
 
-The contrast ratio between two colors is [calculated](http://www.w3.org/TR/WCAG20/#contrast-ratiodef) using their relative luminance values. Keep in mind that the contrast ratios for the opacities given above assume a pure black or white background. Contrast is reduced when text is overlaid on gray or any other color, like the purple shown below. 
+The contrast ratio between two colors is [calculated](http://www.w3.org/TR/WCAG20/#contrast-ratiodef) using their relative luminance values. Keep in mind that the contrast ratios for the opacities given above assume a pure black or white background. Contrast is reduced when text is overlaid on gray or any other color, like the purple shown below.
 
 ![Colors](/img/guides/contrast-ratios.png)
 
@@ -106,8 +106,8 @@ If possible, try to choose font sizes that work well across devices. For Sailec,
 
 Good typography requires a lot of attention to detail, and not just regarding font sizes and line heights. Get up to speed on all the best practices by reading through the [Flawless Typography Checklist](https://app.typographychecklist.com/). Here are some highlights:
 
-* Use proper apostrophes and quotes (`’` and `”` instead of `'` and `"`), proper dashes (`—` instead of `--`), and other typographic characters (`×` instead of `x`) whenever possible.
-* Use an “interpunct” or “middot” character (`·`) to separate items in a horizontal list instead of dashes, pipes, or bullets.
+- Use proper apostrophes and quotes (`’` and `”` instead of `'` and `"`), proper dashes (`—` instead of `--`), and other typographic characters (`×` instead of `x`) whenever possible.
+- Use an “interpunct” or “middot” character (`·`) to separate items in a horizontal list instead of dashes, pipes, or bullets.
 
 Remember to adhere to Amino's editorial style guide for grammar and punctuation, and always write good, concise copy.
 
@@ -119,24 +119,22 @@ Here's a native system font stack borrowed from [Bootstrap 4](https://v4-alpha.g
 
 ```scss
 $font-family-sans-serif:
-  // Safari for OS X and iOS (San Francisco)
-  -apple-system,
+  // Safari for OS X and iOS (San Francisco) -apple-system,
   // Chrome >= 56 for OS X (San Francisco), Windows, Linux and Android
-  system-ui,
-  // Chrome < 56 for OS X (San Francisco)
-  BlinkMacSystemFont,
+    system-ui, // Chrome < 56 for OS X (San Francisco)
+    BlinkMacSystemFont,
   // Windows
-  "Segoe UI",
-  // Android
-  "Roboto",
+    "Segoe UI", // Android
+    "Roboto",
   // Basic web fallback
-  "Helvetica Neue", Arial, sans-serif !default;
+    "Helvetica Neue", Arial, sans-serif !default;
 ```
 
 And here is the same stack as plain old CSS:
 
 ```scss
-font-family: "Sailec", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", "Roboto", "Helvetica Neue", Arial, sans-serif;
+font-family: "Sailec", -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI",
+  "Roboto", "Helvetica Neue", Arial, sans-serif;
 ```
 
 ---

--- a/guides/04-color.md
+++ b/guides/04-color.md
@@ -4,15 +4,15 @@ status: stable
 
 ### Primary colors
 
-Amino's primary color palette consists of vibrant shades of **orange, red, purple, blue, and green**. The colors are inspired by the Amino logo, and the green is added to complete the set and support product UI needs. 
+Amino's primary color palette consists of vibrant shades of **orange, red, purple, blue, and green**. The colors are inspired by the Amino logo, and the green is added to complete the set and support product UI needs.
 
 ![Primary color palette](/img/guides/colors.png)
 
 If you need a shade that isn't shown here, first consider whether that's really true, and if it is, **interpolate thoughtfully** between the two closest ones. Try doing so in a variety of color spaces (RGB, HSL, and HSB) and pick the one that works best. Here's an example:
 
-* Say you need a color between the darkest purple (`#2F0047`) and the next darkest (`#58166E`)
-* In HSB, those colors are `(280, 100, 28)` and `(285, 80, 43)`, respectively
-* Interpolating equally between the two in HSB, we get `(283, 90, 36)`, or `#44095C`
+- Say you need a color between the darkest purple (`#2F0047`) and the next darkest (`#58166E`)
+- In HSB, those colors are `(280, 100, 28)` and `(285, 80, 43)`, respectively
+- Interpolating equally between the two in HSB, we get `(283, 90, 36)`, or `#44095C`
 
 Tables are provided in the appendix with copyable hex, RGB, HSB, and HSL values.
 
@@ -32,7 +32,7 @@ Don't overdo it with the gradients. For better or worse, bright gradients are cu
 
 ![Gradient tips](/img/guides/gradient-tips.png)
 
-For large areas of gradient fill, pin the **lighter color to the top-right corner** and the **darker color to the bottom-left corner**, simulating a consistent soft light source. 
+For large areas of gradient fill, pin the **lighter color to the top-right corner** and the **darker color to the bottom-left corner**, simulating a consistent soft light source.
 
 On elements that appear as strips, slabs, or bars, **don't apply gradients “against the grain,”** which creates a dated-looking rounded or beveled effect. For thin strips, apply the gradient **in parallel** with the long edge of the strip, and go from **one end to the other**. It's generally best to **avoid gradients for slabs and bars**, as they tend to distract and yank the eye.
 
@@ -42,125 +42,123 @@ On elements that appear as strips, slabs, or bars, **don't apply gradients “ag
 
 [macOS color scheme file](https://www.dropbox.com/s/rjca2ssg5i6bvq6/phenotypes.clr?dl=0) ← Put this in `~/Library/Colors` and it will show up in the system color picker that Keynote and other apps use.
 
-Orange | Name | Hex | RGB | HSB | HSL
----|---|---|---|---|---
- <div class="colorChip" style="background: #FFC67F;"></div> | orange-100 | #FFC67F | 255, 198, 127 | 33, 50, 100 | 33, 100, 75
- <div class="colorChip" style="background: #FC8626;"></div> | orange-200 | #FC8626 | 252, 134, 38 | 27, 85, 99 | 27, 97, 57
- <div class="colorChip" style="background: #CD5000;"></div> | orange-300 | #CD5000 | 207, 79, 0 | 23, 100, 81 | 23, 100, 41
- <div class="colorChip" style="background: #992800;"></div> | orange-400 | #992800 | 153, 41, 0 | 16, 100, 60 | 16, 100, 30
- <div class="colorChip" style="background: #631000;"></div> | orange-500 | #631000 | 99, 17, 0 | 10, 100, 39 | 10, 100, 20
+| Orange                                                     | Name       | Hex     | RGB           | HSB         | HSL         |
+| ---------------------------------------------------------- | ---------- | ------- | ------------- | ----------- | ----------- |
+| <div class="colorChip" style="background: #FFC67F;"></div> | orange-100 | #FFC67F | 255, 198, 127 | 33, 50, 100 | 33, 100, 75 |
+| <div class="colorChip" style="background: #FC8626;"></div> | orange-200 | #FC8626 | 252, 134, 38  | 27, 85, 99  | 27, 97, 57  |
+| <div class="colorChip" style="background: #CD5000;"></div> | orange-300 | #CD5000 | 207, 79, 0    | 23, 100, 81 | 23, 100, 41 |
+| <div class="colorChip" style="background: #992800;"></div> | orange-400 | #992800 | 153, 41, 0    | 16, 100, 60 | 16, 100, 30 |
+| <div class="colorChip" style="background: #631000;"></div> | orange-500 | #631000 | 99, 17, 0     | 10, 100, 39 | 10, 100, 20 |
 
-Red | Name | Hex | RGB | HSB | HSL
----|---|---|---|---|---
- <div class="colorChip" style="background: #FF979A;"></div> | red-100 | #FF979A | 255, 150, 154 | 358, 41, 100 | 358, 100, 80
- <div class="colorChip" style="background: #F04D5D;"></div> | red-200 | #F04D5D | 240, 77, 93 | 354, 68, 94 | 354, 84, 62
- <div class="colorChip" style="background: #BD2B43;"></div> | red-300 | #BD2B43 | 189, 43, 68 | 350, 77, 74 | 350, 63, 46
- <div class="colorChip" style="background: #8C092C;"></div> | red-400 | #8C092C | 140, 10, 45 | 344, 93, 55 | 344, 87, 29
- <div class="colorChip" style="background: #4A001E;"></div> | red-500 | #4A001E | 74, 0, 31 | 335, 100, 29 | 335, 100, 14
+| Red                                                        | Name    | Hex     | RGB           | HSB          | HSL          |
+| ---------------------------------------------------------- | ------- | ------- | ------------- | ------------ | ------------ |
+| <div class="colorChip" style="background: #FF979A;"></div> | red-100 | #FF979A | 255, 150, 154 | 358, 41, 100 | 358, 100, 80 |
+| <div class="colorChip" style="background: #F04D5D;"></div> | red-200 | #F04D5D | 240, 77, 93   | 354, 68, 94  | 354, 84, 62  |
+| <div class="colorChip" style="background: #BD2B43;"></div> | red-300 | #BD2B43 | 189, 43, 68   | 350, 77, 74  | 350, 63, 46  |
+| <div class="colorChip" style="background: #8C092C;"></div> | red-400 | #8C092C | 140, 10, 45   | 344, 93, 55  | 344, 87, 29  |
+| <div class="colorChip" style="background: #4A001E;"></div> | red-500 | #4A001E | 74, 0, 31     | 335, 100, 29 | 335, 100, 14 |
 
-Purple | Name | Hex | RGB | HSB | HSL
----|---|---|---|---|---
- <div class="colorChip" style="background: #E39AE3;"></div> | purple-100 | #E39AE3 | 227, 154, 227 | 300, 32, 89 | 300, 56, 75
- <div class="colorChip" style="background: #B35DBA;"></div> | purple-200 | #B35DBA | 178, 93, 186 | 295, 50, 73 | 295, 40, 55
- <div class="colorChip" style="background: #853B94;"></div> | purple-300 | #853B94 | 133, 59, 148 | 290, 60, 58 | 290, 43, 41
- <div class="colorChip" style="background: #58166E;"></div> | purple-400 | #58166E | 88, 22, 110 | 285, 80, 43 | 285, 67, 26
- <div class="colorChip" style="background: #2F0047;"></div> | purple-500 | #2F0047 | 48, 0, 71 | 280, 100, 28 | 280, 100, 14
+| Purple                                                     | Name       | Hex     | RGB           | HSB          | HSL          |
+| ---------------------------------------------------------- | ---------- | ------- | ------------- | ------------ | ------------ |
+| <div class="colorChip" style="background: #E39AE3;"></div> | purple-100 | #E39AE3 | 227, 154, 227 | 300, 32, 89  | 300, 56, 75  |
+| <div class="colorChip" style="background: #B35DBA;"></div> | purple-200 | #B35DBA | 178, 93, 186  | 295, 50, 73  | 295, 40, 55  |
+| <div class="colorChip" style="background: #853B94;"></div> | purple-300 | #853B94 | 133, 59, 148  | 290, 60, 58  | 290, 43, 41  |
+| <div class="colorChip" style="background: #58166E;"></div> | purple-400 | #58166E | 88, 22, 110   | 285, 80, 43  | 285, 67, 26  |
+| <div class="colorChip" style="background: #2F0047;"></div> | purple-500 | #2F0047 | 48, 0, 71     | 280, 100, 28 | 280, 100, 14 |
 
-Blue | Name | Hex | RGB | HSB | HSL
----|---|---|---|---|---
- <div class="colorChip" style="background: #7FEAFF;"></div> | blue-100 | #7FEAFF | 128, 234, 255 | 190, 50, 100 | 190, 100, 75
- <div class="colorChip" style="background: #16B8E0;"></div> | blue-200 | #16B8E0 | 22, 184, 224 | 192, 90, 88 | 192, 82, 48
- <div class="colorChip" style="background: #008AB3;"></div> | blue-300 | #008AB3 | 0, 138, 179 | 194, 100, 70 | 194, 100, 35
- <div class="colorChip" style="background: #005678;"></div> | blue-400 | #005678 | 0, 86, 120 | 197, 100, 47 | 197, 100, 24
- <div class="colorChip" style="background: #00253F;"></div> | blue-500 | #00253F | 0, 37, 64 | 205, 100, 25 | 205, 100, 13
+| Blue                                                       | Name     | Hex     | RGB           | HSB          | HSL          |
+| ---------------------------------------------------------- | -------- | ------- | ------------- | ------------ | ------------ |
+| <div class="colorChip" style="background: #7FEAFF;"></div> | blue-100 | #7FEAFF | 128, 234, 255 | 190, 50, 100 | 190, 100, 75 |
+| <div class="colorChip" style="background: #16B8E0;"></div> | blue-200 | #16B8E0 | 22, 184, 224  | 192, 90, 88  | 192, 82, 48  |
+| <div class="colorChip" style="background: #008AB3;"></div> | blue-300 | #008AB3 | 0, 138, 179   | 194, 100, 70 | 194, 100, 35 |
+| <div class="colorChip" style="background: #005678;"></div> | blue-400 | #005678 | 0, 86, 120    | 197, 100, 47 | 197, 100, 24 |
+| <div class="colorChip" style="background: #00253F;"></div> | blue-500 | #00253F | 0, 37, 64     | 205, 100, 25 | 205, 100, 13 |
 
-Green | Name | Hex | RGB | HSB | HSL
----|---|---|---|---|---
- <div class="colorChip" style="background: #89F0CF;"></div> | green-100 | #89F0CF | 137, 240, 207 | 161, 43, 94 | 161, 77, 74
- <div class="colorChip" style="background: #2DCFA1;"></div> | green-200 | #2DCFA1 | 45, 207, 161 | 163, 78, 81 | 163, 64, 49
- <div class="colorChip" style="background: #03AB8C;"></div> | green-300 | #03AB8C | 3, 171, 140 | 169, 98, 67 | 169, 96, 34
- <div class="colorChip" style="background: #007868;"></div> | green-400 | #007868 | 0, 120, 104 | 172, 100, 47 | 172, 100, 24
- <div class="colorChip" style="background: #003F3E;"></div> | green-500 | #003F3E | 0, 64, 63 | 179, 100, 25 | 179, 100, 13
+| Green                                                      | Name      | Hex     | RGB           | HSB          | HSL          |
+| ---------------------------------------------------------- | --------- | ------- | ------------- | ------------ | ------------ |
+| <div class="colorChip" style="background: #89F0CF;"></div> | green-100 | #89F0CF | 137, 240, 207 | 161, 43, 94  | 161, 77, 74  |
+| <div class="colorChip" style="background: #2DCFA1;"></div> | green-200 | #2DCFA1 | 45, 207, 161  | 163, 78, 81  | 163, 64, 49  |
+| <div class="colorChip" style="background: #03AB8C;"></div> | green-300 | #03AB8C | 3, 171, 140   | 169, 98, 67  | 169, 96, 34  |
+| <div class="colorChip" style="background: #007868;"></div> | green-400 | #007868 | 0, 120, 104   | 172, 100, 47 | 172, 100, 24 |
+| <div class="colorChip" style="background: #003F3E;"></div> | green-500 | #003F3E | 0, 64, 63     | 179, 100, 25 | 179, 100, 13 |
 
-Orange gradient | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #FC8626;"></div> | #FC8626 | 252, 134, 38 | 27, 85, 99 | 27, 97, 57
-<div class="colorChip" style="background: #CD5000;"></div> | #CD5000 | 205, 80, 0 | 23, 100, 80 | 23, 100, 40
+| Orange gradient                                            | Hex     | RGB          | HSB         | HSL         |
+| ---------------------------------------------------------- | ------- | ------------ | ----------- | ----------- |
+| <div class="colorChip" style="background: #FC8626;"></div> | #FC8626 | 252, 134, 38 | 27, 85, 99  | 27, 97, 57  |
+| <div class="colorChip" style="background: #CD5000;"></div> | #CD5000 | 205, 80, 0   | 23, 100, 80 | 23, 100, 40 |
 
-Red gradient | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #F04D5D;"></div> | #F04D5D | 240, 77, 93 | 354, 68, 94 | 354, 84, 62
-<div class="colorChip" style="background: #8C092C;"></div> | #8C092C | 140, 9, 44 | 344, 94, 55 | 344, 88, 29
+| Red gradient                                               | Hex     | RGB         | HSB         | HSL         |
+| ---------------------------------------------------------- | ------- | ----------- | ----------- | ----------- |
+| <div class="colorChip" style="background: #F04D5D;"></div> | #F04D5D | 240, 77, 93 | 354, 68, 94 | 354, 84, 62 |
+| <div class="colorChip" style="background: #8C092C;"></div> | #8C092C | 140, 9, 44  | 344, 94, 55 | 344, 88, 29 |
 
-Purple gradient | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #B25DBA;"></div> | #B25DBA | 178, 93, 186 | 295, 50, 73 | 295, 40, 55
-<div class="colorChip" style="background: #58166E;"></div> | #58166E | 88, 22, 110 | 285, 80, 43 | 285, 67, 26
+| Purple gradient                                            | Hex     | RGB          | HSB         | HSL         |
+| ---------------------------------------------------------- | ------- | ------------ | ----------- | ----------- |
+| <div class="colorChip" style="background: #B25DBA;"></div> | #B25DBA | 178, 93, 186 | 295, 50, 73 | 295, 40, 55 |
+| <div class="colorChip" style="background: #58166E;"></div> | #58166E | 88, 22, 110  | 285, 80, 43 | 285, 67, 26 |
 
-Blue gradient | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #16B8E0;"></div> | #16B8E0 | 22, 184, 224 | 192, 90, 88 | 192, 82, 48
-<div class="colorChip" style="background: #005678;"></div> | #005678 | 0, 86, 120 | 197, 100, 47 | 197, 100, 24
+| Blue gradient                                              | Hex     | RGB          | HSB          | HSL          |
+| ---------------------------------------------------------- | ------- | ------------ | ------------ | ------------ |
+| <div class="colorChip" style="background: #16B8E0;"></div> | #16B8E0 | 22, 184, 224 | 192, 90, 88  | 192, 82, 48  |
+| <div class="colorChip" style="background: #005678;"></div> | #005678 | 0, 86, 120   | 197, 100, 47 | 197, 100, 24 |
 
-Green gradient | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #2DCFA1;"></div> | #2DCFA1 | 45, 207, 161 | 163, 78, 81 | 163, 64, 49
-<div class="colorChip" style="background: #007868;"></div> | #007868 | 0, 120, 104 | 172, 100, 47 | 172, 100, 24
+| Green gradient                                             | Hex     | RGB          | HSB          | HSL          |
+| ---------------------------------------------------------- | ------- | ------------ | ------------ | ------------ |
+| <div class="colorChip" style="background: #2DCFA1;"></div> | #2DCFA1 | 45, 207, 161 | 163, 78, 81  | 163, 64, 49  |
+| <div class="colorChip" style="background: #007868;"></div> | #007868 | 0, 120, 104  | 172, 100, 47 | 172, 100, 24 |
 
-Orange/red | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #FC8626;"></div> | #FC8626 | 252, 134, 38 | 27, 85, 99 | 27, 97, 57
-<div class="colorChip" style="background: #E64253;"></div> | #E64253 | 230, 66, 83 | 354, 71, 90 | 354, 77, 58
+| Orange/red                                                 | Hex     | RGB          | HSB         | HSL         |
+| ---------------------------------------------------------- | ------- | ------------ | ----------- | ----------- |
+| <div class="colorChip" style="background: #FC8626;"></div> | #FC8626 | 252, 134, 38 | 27, 85, 99  | 27, 97, 57  |
+| <div class="colorChip" style="background: #E64253;"></div> | #E64253 | 230, 66, 83  | 354, 71, 90 | 354, 77, 58 |
 
-Red/purple | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #F04D5D;"></div> | #F04D5D | 240, 77, 93 | 354, 68, 94 | 354, 84, 62
-<div class="colorChip" style="background: #892E9C;"></div> | #892E9C | 137, 46, 156 | 290, 71, 61 | 290, 54, 40
+| Red/purple                                                 | Hex     | RGB          | HSB         | HSL         |
+| ---------------------------------------------------------- | ------- | ------------ | ----------- | ----------- |
+| <div class="colorChip" style="background: #F04D5D;"></div> | #F04D5D | 240, 77, 93  | 354, 68, 94 | 354, 84, 62 |
+| <div class="colorChip" style="background: #892E9C;"></div> | #892E9C | 137, 46, 156 | 290, 71, 61 | 290, 54, 40 |
 
-Blue/purple | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #16B8E0;"></div> | #16B8E0 | 22, 184, 224 | 192, 90, 88 | 192, 82, 48
-<div class="colorChip" style="background: #6E3094;"></div> | #6E3094 | 110, 48, 148 | 277, 68, 58 | 277, 51, 38
+| Blue/purple                                                | Hex     | RGB          | HSB         | HSL         |
+| ---------------------------------------------------------- | ------- | ------------ | ----------- | ----------- |
+| <div class="colorChip" style="background: #16B8E0;"></div> | #16B8E0 | 22, 184, 224 | 192, 90, 88 | 192, 82, 48 |
+| <div class="colorChip" style="background: #6E3094;"></div> | #6E3094 | 110, 48, 148 | 277, 68, 58 | 277, 51, 38 |
 
-Green/blue | Hex | RGB | HSB | HSL
----|---|---|---|---
-<div class="colorChip" style="background: #1ADCAE;"></div> | #1ADCAE | 26, 220, 174 | 166, 88, 86 | 166, 79, 48
-<div class="colorChip" style="background: #0076AE;"></div> | #0076AE | 0, 118, 174 | 199, 100, 68 | 199, 100, 34
+| Green/blue                                                 | Hex     | RGB          | HSB          | HSL          |
+| ---------------------------------------------------------- | ------- | ------------ | ------------ | ------------ |
+| <div class="colorChip" style="background: #1ADCAE;"></div> | #1ADCAE | 26, 220, 174 | 166, 88, 86  | 166, 79, 48  |
+| <div class="colorChip" style="background: #0076AE;"></div> | #0076AE | 0, 118, 174  | 199, 100, 68 | 199, 100, 34 |
 
-Gray | Name | Hex | RGB | HSB | HSL
----|---|---|---|---|---|---|---
-<div class="colorChip" style="background: #FFFFFF;"></div> | white | #FFFFFF | 255, 255, 255 | 0, 0, 100 | 0, 0, 100
-<div class="colorChip" style="background: #F9F9F9;"></div> | gray-100 | #F9F9F9 | 249, 249, 249 | 0, 0, 98 | 0, 0, 98
-<div class="colorChip" style="background: #EEEEEE;"></div> | gray-200 | #EEEEEE | 238, 238, 238 | 0, 0, 93 | 0, 0, 93
-<div class="colorChip" style="background: #DBDBDB;"></div> | gray-300 | #DBDBDB | 219, 219, 219 | 0, 0, 86 | 0, 0, 86
-<div class="colorChip" style="background: #C1C1C1;"></div> | gray-400 | #C1C1C1 | 193, 193, 193 | 0, 0, 76 | 0, 0, 76
-<div class="colorChip" style="background: #969696;"></div> | gray-500 | #969696 | 150, 150, 150 | 0, 0, 59 | 0, 0, 59
-<div class="colorChip" style="background: #777777;"></div> | gray-600 | #777777 | 119, 119, 119 | 0, 0, 47 | 0, 0, 47
-<div class="colorChip" style="background: #4D4D4D;"></div> | gray-700 | #4D4D4D | 77, 77, 77 | 0, 0, 30 | 0, 0, 30
-<div class="colorChip" style="background: #232323;"></div> | gray-800 | #232323 | 36, 36, 36 | 0, 0, 14 | 0, 0, 14
-<div class="colorChip" style="background: #000000;"></div> | black | #000000 | 0, 0, 0 | 0, 0, 0 | 0, 0, 0
+| Gray                                                       | Name     | Hex     | RGB           | HSB       | HSL       |
+| ---------------------------------------------------------- | -------- | ------- | ------------- | --------- | --------- |
+| <div class="colorChip" style="background: #FFFFFF;"></div> | white    | #FFFFFF | 255, 255, 255 | 0, 0, 100 | 0, 0, 100 |
+| <div class="colorChip" style="background: #F9F9F9;"></div> | gray-100 | #F9F9F9 | 249, 249, 249 | 0, 0, 98  | 0, 0, 98  |
+| <div class="colorChip" style="background: #EEEEEE;"></div> | gray-200 | #EEEEEE | 238, 238, 238 | 0, 0, 93  | 0, 0, 93  |
+| <div class="colorChip" style="background: #DBDBDB;"></div> | gray-300 | #DBDBDB | 219, 219, 219 | 0, 0, 86  | 0, 0, 86  |
+| <div class="colorChip" style="background: #C1C1C1;"></div> | gray-400 | #C1C1C1 | 193, 193, 193 | 0, 0, 76  | 0, 0, 76  |
+| <div class="colorChip" style="background: #969696;"></div> | gray-500 | #969696 | 150, 150, 150 | 0, 0, 59  | 0, 0, 59  |
+| <div class="colorChip" style="background: #777777;"></div> | gray-600 | #777777 | 119, 119, 119 | 0, 0, 47  | 0, 0, 47  |
+| <div class="colorChip" style="background: #4D4D4D;"></div> | gray-700 | #4D4D4D | 77, 77, 77    | 0, 0, 30  | 0, 0, 30  |
+| <div class="colorChip" style="background: #232323;"></div> | gray-800 | #232323 | 36, 36, 36    | 0, 0, 14  | 0, 0, 14  |
+| <div class="colorChip" style="background: #000000;"></div> | black    | #000000 | 0, 0, 0       | 0, 0, 0   | 0, 0, 0   |
 
-Black alpha | Name | Value | Usage
----|---|---|---
-<div class="colorChip" style="background: #F9F9F9;"></div> | alpha-100 | 0.02| 
-<div class="colorChip" style="background: #EEEEEE;"></div> | alpha-200 | 0.07| 
-<div class="colorChip" style="background: #DBDBDB;"></div> | alpha-300 | 0.14| 
-<div class="colorChip" style="background: #C1C1C1;"></div> | alpha-400 | 0.24| 
-<div class="colorChip" style="background: #969696;"></div> | alpha-500 | 0.41| Hint
-<div class="colorChip" style="background: #777777;"></div> | alpha-600 | 0.54| Secondary
-<div class="colorChip" style="background: #4D4D4D;"></div> | alpha-700 | 0.70| 
-<div class="colorChip" style="background: #232323;"></div> | alpha-800 | 0.86| Primary
+| Black alpha                                                | Name      | Value | Usage     |
+| ---------------------------------------------------------- | --------- | ----- | --------- |
+| <div class="colorChip" style="background: #F9F9F9;"></div> | alpha-100 | 0.02  |
+| <div class="colorChip" style="background: #EEEEEE;"></div> | alpha-200 | 0.07  |
+| <div class="colorChip" style="background: #DBDBDB;"></div> | alpha-300 | 0.14  |
+| <div class="colorChip" style="background: #C1C1C1;"></div> | alpha-400 | 0.24  |
+| <div class="colorChip" style="background: #969696;"></div> | alpha-500 | 0.41  | Hint      |
+| <div class="colorChip" style="background: #777777;"></div> | alpha-600 | 0.54  | Secondary |
+| <div class="colorChip" style="background: #4D4D4D;"></div> | alpha-700 | 0.70  |
+| <div class="colorChip" style="background: #232323;"></div> | alpha-800 | 0.86  | Primary   |
 
-White/reversed alpha | Name | Value | Usage
----|---|---|---
-<div class="colorChip" style="background: #232323;"></div> | alpha-reversed-100 | 0.14| 
-<div class="colorChip" style="background: #4D4D4D;"></div> | alpha-reversed-200 | 0.30| 
-<div class="colorChip" style="background: #777777;"></div> | alpha-reversed-300 | 0.46| 
-<div class="colorChip" style="background: #969696;"></div> | alpha-reversed-400 | 0.59| Hint
-<div class="colorChip" style="background: #C1C1C1;"></div> | alpha-reversed-500 | 0.76| Secondary
-<div class="colorChip" style="background: #DBDBDB;"></div> | alpha-reversed-600 | 0.86| 
-<div class="colorChip" style="background: #EEEEEE;"></div> | alpha-reversed-700 | 0.93| 
-<div class="colorChip" style="background: #F9F9F9;"></div> | alpha-reversed-800 | 0.98| 
-| white | 1.0 | Primary
-
-
+| White/reversed alpha                                       | Name               | Value   | Usage     |
+| ---------------------------------------------------------- | ------------------ | ------- | --------- |
+| <div class="colorChip" style="background: #232323;"></div> | alpha-reversed-100 | 0.14    |
+| <div class="colorChip" style="background: #4D4D4D;"></div> | alpha-reversed-200 | 0.30    |
+| <div class="colorChip" style="background: #777777;"></div> | alpha-reversed-300 | 0.46    |
+| <div class="colorChip" style="background: #969696;"></div> | alpha-reversed-400 | 0.59    | Hint      |
+| <div class="colorChip" style="background: #C1C1C1;"></div> | alpha-reversed-500 | 0.76    | Secondary |
+| <div class="colorChip" style="background: #DBDBDB;"></div> | alpha-reversed-600 | 0.86    |
+| <div class="colorChip" style="background: #EEEEEE;"></div> | alpha-reversed-700 | 0.93    |
+| <div class="colorChip" style="background: #F9F9F9;"></div> | alpha-reversed-800 | 0.98    |
+| white                                                      | 1.0                | Primary |

--- a/guides/05-logo.md
+++ b/guides/05-logo.md
@@ -5,9 +5,9 @@ status: stable
 
 ![Amino logo](/img/guides/logo-primary.png)
 
-The logo is the keystone of the Amino brand and consists of two elements: the **mark** and the **logotype**. The current version of the logo is a Phenotypes-based evolution of previous versions. While it aims to maintain a connection to the past, the Amino logo is now a better representation of our brand attributes—clarity, confidence, and optimism. 
+The logo is the keystone of the Amino brand and consists of two elements: the **mark** and the **logotype**. The current version of the logo is a Phenotypes-based evolution of previous versions. While it aims to maintain a connection to the past, the Amino logo is now a better representation of our brand attributes—clarity, confidence, and optimism.
 
-The Amino logo is Phenotypes through and through, which creates a high degree of cohesion between the brand identity and the context in which it appears, whether that’s an interactive product screen or a printed pamphlet. 
+The Amino logo is Phenotypes through and through, which creates a high degree of cohesion between the brand identity and the context in which it appears, whether that’s an interactive product screen or a printed pamphlet.
 
 The full-color **lockups** (mark + logotype) above are the preferred treatment of the Amino logo. The one with dark purple text should be used on a white or very light gray background. The one with white text (a.k.a. **reversed**) should be used on dark purple, dark gray/black, or any other color that is dark enough to provide sufficient contrast with the logo and complements the colors of the mark.
 
@@ -25,12 +25,12 @@ In situations where the full-color versions of the logo won’t work (e.g. on to
 
 The logo has been lovingly crafted using Phenotypes principles as a starting point and optical adjustments for balance and polish. The logo is built using the modular scale for proportions, sizing, and spacing. The mark’s color palette is chosen from Phenotypes colors. The logotype is based on Sailec (medium weight) with some modifications. If you’re curious, here are some construction notes to go with the diagram above:
 
-* The mark sits in an equilateral triangle with side length `c`
-* The logotype is set in Sailec Medium with at a size of `c` pts
-* The top circle in the mark: `a = c / (8/7)^14`
-* The bottom circles of the mark: `b = a / (8/7)`
-* The distance between the mark and the logotype is the radius of the top circle
-* The baseline of the logotype is aligned with the points on the bottom circles of the mark where the straight lines attach tangentially
+- The mark sits in an equilateral triangle with side length `c`
+- The logotype is set in Sailec Medium with at a size of `c` pts
+- The top circle in the mark: `a = c / (8/7)^14`
+- The bottom circles of the mark: `b = a / (8/7)`
+- The distance between the mark and the logotype is the radius of the top circle
+- The baseline of the logotype is aligned with the points on the bottom circles of the mark where the straight lines attach tangentially
 
 All that said, **please don’t do weird stuff with the logo**. To ensure that the logo appears consistently and proudly, use the provided files as they are. While it’s fine to resize the images to suit your needs, don’t change colors, spacing, proportions, or other attributes that make the logo what it is.
 
@@ -40,17 +40,17 @@ All that said, **please don’t do weird stuff with the logo**. To ensure that t
 
 Always surround the logo or mark with ample clear space (the minimum clear space is shown above). Here are some more guidelines for using the Amino logo with best results:
 
-* Even when using the mono versions of the logo, make sure there’s sufficient contrast with the background.
-* Don’t distort, rotate, or otherwise manipulate the logo’s shapes.
-* Don’t apply effects, like gradients, shadows, outlines, image masks, or filters.
-* Don’t use the logo as a decorative element or as a component of an illustration.
+- Even when using the mono versions of the logo, make sure there’s sufficient contrast with the background.
+- Don’t distort, rotate, or otherwise manipulate the logo’s shapes.
+- Don’t apply effects, like gradients, shadows, outlines, image masks, or filters.
+- Don’t use the logo as a decorative element or as a component of an illustration.
 
 And some logistical suggestions:
 
-* Use the right file for the job. Print files are provided in cmyk color and screen files are provided in rgb. Various formats of each are provided.
-* Use the vector files when possible. For example, you can drag the .ai (Illustrator) files directly into Keynote and resize infinitely. The .svg files can be used similarly on the web, in Sketch, and in many other applications.
-* Use the provided .png files as needed, but never enlarge them. While it’s okay to shrink them, it’s better to create a new .png file at exactly the size you need from one of the vector files. You can do this easily without special software at a site like myScale: just upload the .svg for the version of the logo you want, specify the width of the .png you need, and you’re good to go.
-* Ready made app icons for web, iOS, and Android are provided. These are optimized for their respective platforms and adhere to relevant platform visual guidelines. Avoid using them for other purposes.
-* To create a new icon or account avatar (e.g. social media), use the icon light and icon dark files, which are already set up with internal margins based on the modular scale and optical adjustments.
+- Use the right file for the job. Print files are provided in cmyk color and screen files are provided in rgb. Various formats of each are provided.
+- Use the vector files when possible. For example, you can drag the .ai (Illustrator) files directly into Keynote and resize infinitely. The .svg files can be used similarly on the web, in Sketch, and in many other applications.
+- Use the provided .png files as needed, but never enlarge them. While it’s okay to shrink them, it’s better to create a new .png file at exactly the size you need from one of the vector files. You can do this easily without special software at a site like myScale: just upload the .svg for the version of the logo you want, specify the width of the .png you need, and you’re good to go.
+- Ready made app icons for web, iOS, and Android are provided. These are optimized for their respective platforms and adhere to relevant platform visual guidelines. Avoid using them for other purposes.
+- To create a new icon or account avatar (e.g. social media), use the icon light and icon dark files, which are already set up with internal margins based on the modular scale and optical adjustments.
 
 ### [Download Amino logo files](https://www.dropbox.com/s/fq5981ebiduww03/amino%20logo%2021.zip?dl=1) (17MB zip file)

--- a/guides/06-spacing.md
+++ b/guides/06-spacing.md
@@ -18,11 +18,11 @@ These numbers use the same modular scale as the typography system. With the exce
 
 Here are some ways to use the modular scale to decide on spacing and sizing:
 
-* Use one of the numbers above as a padding, margin, or offset value
-* Use one of the numbers above as an element's overall height/width and center its contents vertically/horizontally
-* Use an aspect ratio from the modular scale along with a fixed dimension to pick the other other dimension. E.g. if you have an element that must be 800px wide and you need to pick a height for it, consider `800px × [(8/7)^-4] ≈ 470px`.
-* Use the numbers above as guidelines (or keylines). E.g. if you have one column of variable-width thin labels and a second column of longer text, the first column could be inset 36px from the edge of the container, and the second column could be inset 119px from the edge.
-* Mix and match these techniques as needed
+- Use one of the numbers above as a padding, margin, or offset value
+- Use one of the numbers above as an element's overall height/width and center its contents vertically/horizontally
+- Use an aspect ratio from the modular scale along with a fixed dimension to pick the other other dimension. E.g. if you have an element that must be 800px wide and you need to pick a height for it, consider `800px × [(8/7)^-4] ≈ 470px`.
+- Use the numbers above as guidelines (or keylines). E.g. if you have one column of variable-width thin labels and a second column of longer text, the first column could be inset 36px from the edge of the container, and the second column could be inset 119px from the edge.
+- Mix and match these techniques as needed
 
 ### Yeah, but what if...
 
@@ -33,14 +33,14 @@ Phenotypes aims to balance simplicity and flexibility, but no spacing system can
 ## Appendix
 
 | SASS variable | Space |
-| -------- | ----- |
-| `$spacer-0` | 0 |
-| `$spacer-1` | 5px |
-| `$spacer-2` | 7px |
-| `$spacer-3` | 11px |
-| `$spacer-4` | 16px |
-| `$spacer-5` | 24px |
-| `$spacer-6` | 36px |
-| `$spacer-7` | 53px |
-| `$spacer-8` | 79px |
-| `$spacer-9` | 119px |
+| ------------- | ----- |
+| `$spacer-0`   | 0     |
+| `$spacer-1`   | 5px   |
+| `$spacer-2`   | 7px   |
+| `$spacer-3`   | 11px  |
+| `$spacer-4`   | 16px  |
+| `$spacer-5`   | 24px  |
+| `$spacer-6`   | 36px  |
+| `$spacer-7`   | 53px  |
+| `$spacer-8`   | 79px  |
+| `$spacer-9`   | 119px |

--- a/guides/07-layout.md
+++ b/guides/07-layout.md
@@ -8,13 +8,13 @@ Phenotypes encourages a mobile-first approach for both design and development. T
 
 Phenotypes groups devices into the following buckets:
 
-| Bucket | Abbreviation | Min | Max | Devices |
-| ------ | ------------ | --- | --- | ------- |
-| Extra small | `xs` | **0** | 599px | Phones |
-| Small | `sm` | **600px** | 899px | Tablet portrait |
-| Medium | `md` | **900px** | 1199px | Tablet + desktop |
-| Large | `lg` | **1200px** | 1499px | Desktop |
-| Extra large | `xl` | **1500px** | ∞ | Big monitor |
+| Bucket      | Abbreviation | Min        | Max     | Devices          |
+| ----------- | ------------ | ---------- | ------- | ---------------- |
+| Extra small | `xs`         | **0**      | 599px   | Phones           |
+| Small       | `sm`         | **600px**  | 899px   | Tablet portrait  |
+| Medium      | `md`         | **900px**  | 1199px  | Tablet + desktop |
+| Large       | `lg`         | **1200px** |  1499px | Desktop          |
+| Extra large | `xl`         | **1500px** | ∞       | Big monitor      |
 
 Since this is a mobile-first system, the breakpoints correspond to each range's minimum value (bold above): 600px, 900px, 1200px, 1500px. Note that the number of breakpoints and their names are the same as Bootstrap, but the breakpoint values are [optimized for bucketing](https://medium.freecodecamp.com/the-100-correct-way-to-do-css-breakpoints-88d6a5ba1862) rather than hewing to exact device sizes.
 

--- a/guides/08-icons.md
+++ b/guides/08-icons.md
@@ -14,7 +14,7 @@ Nucleo comes in three flavors: outline, glyph (solid), and color. The 16px size 
 
 ### Apps
 
-Nucleo provides a **Mac app and a web app** for icon management. When using these apps, be sure the outline style icons are set to use a 2px stroke weight and rounded caps/corners. 
+Nucleo provides a **Mac app and a web app** for icon management. When using these apps, be sure the outline style icons are set to use a 2px stroke weight and rounded caps/corners.
 
 The Mac app is super handy for searching and quickly dragging and dropping an icon into Sketch, Photoshop, or pretty much any other software. When you drag an icon out of the Mac app, it automatically creates an SVG with a unique and recognizable name, which should become the layer name in the design software when you drop the icon. Come implementation time, that name should make it very easy for your developer friends to identify the corresponding icon files.
 
@@ -32,7 +32,7 @@ Amino has a lifetime team license for Nucleo icons and the apps. Just ask for an
 
 If you're logged in to the Nucleo website, you can download the following resources:
 
-* [Mac app](https://nucleoapp.com/download/mac/latest)
-* [Complete SVG icons set](https://nucleoapp.com/source-files/)
+- [Mac app](https://nucleoapp.com/download/mac/latest)
+- [Complete SVG icons set](https://nucleoapp.com/source-files/)
 
 We also keep an archive of the [SVG icons in Dropbox](https://www.dropbox.com/s/nf8hfb3o4dkah7i/Nucleo%20Icons.zip?dl=0), though they might not be up to date (new icons are added regularly).

--- a/guides/09-depth-shadows.md
+++ b/guides/09-depth-shadows.md
@@ -4,9 +4,9 @@ title: Depth and Shadows
 label: Depth and Shadows
 ---
 
-The visual aesthetic of Phenotypes is mostly "flat" with a little bit of helpful skeuomorphism. To create a sense of clarity, we try to generally rely on whitespace, typographic hierarchy, and flat colors to provide structure in layouts. Too many gradients and shadows can easily make a design feel cluttered and look dated. 
+The visual aesthetic of Phenotypes is mostly "flat" with a little bit of helpful skeuomorphism. To create a sense of clarity, we try to generally rely on whitespace, typographic hierarchy, and flat colors to provide structure in layouts. Too many gradients and shadows can easily make a design feel cluttered and look dated.
 
-That said, a puristic adherance to "flat design" can lead to experiences that feel like prototypes, so Phenotypes has a system for conveying *depth* on screen. Depth is a very useful tool for guiding a user through inherently layered experiences like modal dialogs, popovers, and side drawers. A primary call to action button can look a lot more clickable with a subtle shadow to lift it off the screen.
+That said, a puristic adherance to "flat design" can lead to experiences that feel like prototypes, so Phenotypes has a system for conveying _depth_ on screen. Depth is a very useful tool for guiding a user through inherently layered experiences like modal dialogs, popovers, and side drawers. A primary call to action button can look a lot more clickable with a subtle shadow to lift it off the screen.
 
 ![Shadows](/img/guides/shadows.png)
 
@@ -18,32 +18,30 @@ Similarly to the spacing system, Phenotypes provides the following **5 depth val
 
 Conceptually, these values correspond to an element being lifted off its container by 4px, 7px, etc. An element that is sitting directly on its container (most elements) have a depth of 0.
 
-
 ### Constructing the shadow
 
 An element with a non-zero depth value gets **three component drop shadows**, the parameters of which are calculated using (you guessed it) the modular scale.
 
-||Shadow 1|Shadow 2|Shadow 3|
-|---|---|---|---|
-|**x**|0|0|0|
-|**y**|`depth / (8/7)^3`|`depth / (8/7)^12`|0|
-|**blur**|`depth * (8/7)^3`|`depth / (8/7)^9`|`depth * (8/7)^3`|
-|**alpha**|`0.14`|`0.07`|`0.07`|
+|           | Shadow 1          | Shadow 2           | Shadow 3          |
+| --------- | ----------------- | ------------------ | ----------------- |
+| **x**     | 0                 | 0                  | 0                 |
+| **y**     | `depth / (8/7)^3` | `depth / (8/7)^12` | 0                 |
+| **blur**  | `depth * (8/7)^3` | `depth / (8/7)^9`  | `depth * (8/7)^3` |
+| **alpha** | `0.14`            | `0.07`             | `0.07`            |
 
 ![Shadow construction](/img/guides/shadow-construction.png)
-
 
 ### Organizing the stack
 
 Each depth value corresponds to a functional user interface layer. Most elements can exist at depth 0, so don't go overboard assigning every piece of a layout to different depths. When you need to use depth to clarify hierarchy or provide affordance, do keep elements organized into the following layers.
 
-|Depth|Function|Examples|
-|---|---|---|
-|**4**|Structural|Cards, header|
-|**7**|Interactive|CTA button|
-|**11**|Transitional|Hovered CTA button, dragged element|
-|**16**|Disclosures|Popovers, menus|
-|**24**|Mode switch|Modal dialogs, side menu|
+| Depth  | Function     | Examples                            |
+| ------ | ------------ | ----------------------------------- |
+| **4**  | Structural   | Cards, header                       |
+| **7**  | Interactive  | CTA button                          |
+| **11** | Transitional | Hovered CTA button, dragged element |
+| **16** | Disclosures  | Popovers, menus                     |
+| **24** | Mode switch  | Modal dialogs, side menu            |
 
 An element can move up or down in z-space, perhaps as the result of user interaction. If possible, the element should move from one prescribed depth value to another, with a smooth transition between the two. A subtle change in size and y-position dramatically improves the illusion of a depth transition.
 
@@ -57,49 +55,45 @@ Here are all the shadow parameters for the five depth values:
 
 ### Depth 4
 
-||Shadow 1|Shadow 2|Shadow 3|
-|---|---|---|---|
-|**x**|0|0|0|
-|**y**|3px|1px|0|
-|**blur**|6px|1px|6px|
-|**alpha**|`0.14`|`0.07`|`0.07`|
-
+|           | Shadow 1 | Shadow 2 | Shadow 3 |
+| --------- | -------- | -------- | -------- |
+| **x**     | 0        | 0        | 0        |
+| **y**     | 3px      | 1px      | 0        |
+| **blur**  | 6px      | 1px      | 6px      |
+| **alpha** | `0.14`   | `0.07`   | `0.07`   |
 
 ### Depth 7
 
-||Shadow 1|Shadow 2|Shadow 3|
-|---|---|---|---|
-|**x**|0|0|0|
-|**y**|5px|1px|0|
-|**blur**|10px|2px|10px|
-|**alpha**|`0.14`|`0.07`|`0.07`|
-
+|           | Shadow 1 | Shadow 2 | Shadow 3 |
+| --------- | -------- | -------- | -------- |
+| **x**     | 0        | 0        | 0        |
+| **y**     | 5px      | 1px      | 0        |
+| **blur**  | 10px     | 2px      | 10px     |
+| **alpha** | `0.14`   | `0.07`   | `0.07`   |
 
 ### Depth 11
 
-||Shadow 1|Shadow 2|Shadow 3|
-|---|---|---|---|
-|**x**|0|0|0|
-|**y**|7px|2px|0|
-|**blur**|16px|3px|16px|
-|**alpha**|`0.14`|`0.07`|`0.07`|
-
+|           | Shadow 1 | Shadow 2 | Shadow 3 |
+| --------- | -------- | -------- | -------- |
+| **x**     | 0        | 0        | 0        |
+| **y**     | 7px      | 2px      | 0        |
+| **blur**  | 16px     | 3px      | 16px     |
+| **alpha** | `0.14`   | `0.07`   | `0.07`   |
 
 ### Depth 16
 
-||Shadow 1|Shadow 2|Shadow 3|
-|---|---|---|---|
-|**x**|0|0|0|
-|**y**|11px|3px|0|
-|**blur**|24px|5px|24px|
-|**alpha**|`0.14`|`0.07`|`0.07`|
-
+|           | Shadow 1 | Shadow 2 | Shadow 3 |
+| --------- | -------- | -------- | -------- |
+| **x**     | 0        | 0        | 0        |
+| **y**     | 11px     | 3px      | 0        |
+| **blur**  | 24px     | 5px      | 24px     |
+| **alpha** | `0.14`   | `0.07`   | `0.07`   |
 
 ### Depth 24
 
-||Shadow 1|Shadow 2|Shadow 3|
-|---|---|---|---|
-|**x**|0|0|0|
-|**y**|16px|5px|0|
-|**blur**|36px|7px|36px|
-|**alpha**|`0.14`|`0.07`|`0.07`|
+|           | Shadow 1 | Shadow 2 | Shadow 3 |
+| --------- | -------- | -------- | -------- |
+| **x**     | 0        | 0        | 0        |
+| **y**     | 16px     | 5px      | 0        |
+| **blur**  | 36px     | 7px      | 36px     |
+| **alpha** | `0.14`   | `0.07`   | `0.07`   |

--- a/guides/10-data-visualization.md
+++ b/guides/10-data-visualization.md
@@ -20,13 +20,11 @@ This guide to data visualization standards and practices is specifically meant f
 2. **Be transparent, truthful, and trustworthy.** The information we present in charts must be clearly decipherable and contain elements that engender trust (e.g. axes start at zero wherever possible). They should also not contain any analytical “black boxes” (e.g. internally derived metrics or proprietary language).<br><br>
 3. **Maximize visual accessibility, especially for mobile screens.** More than 60% of Amino's blog traffic comes from mobile. In practice, optimizing for mobile means thin margins, bold fonts, and lots of contrast. We also use a color scheme that is discernible to people with common types of colorblindness.
 
-
 ---
 
 ## Colors
 
 Color palettes for data visualization need to be bold, distinct, perceptually accurate, and distinguishable to people with [common forms of color blindness](https://nei.nih.gov/health/color_blindness/facts_about). Thankfully, our Amino brand colors check most of these boxes.
-
 
 ### Factors/Categorical
 
@@ -38,19 +36,19 @@ Color palettes for data visualization need to be bold, distinct, perceptually ac
 
 Context is key for selecting the appropriate color ramp. Generally speaking, we start with purple. The diverging scale is used to make a distinction between low and high values, where blue is typically low and orange is typically high. In some cases, coloring via quantiles creates an easier to understand continuous scale.
 
-| |	Diverging | | Blue | | Orange | | Red | | Purple |
-|---|---|---|---|---|---|---|---|---|---|
-| <div class="colorChip" style="background: #16b8e0;"></div> | #16b8e0 | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb |
-| <div class="colorChip" style="background: #61bfdf;"></div> | #61bfdf | <div class="colorChip" style="background: #ced8dc;"></div> | #ced8dc | <div class="colorChip" style="background: #e3d2c9;"></div> | #e3d2c9 | <div class="colorChip" style="background: #e1cfce;"></div> | #e1cfce | <div class="colorChip" style="background: #d3cad4;"></div> | #d3cad4 |
-| <div class="colorChip" style="background: #87c6de;"></div> | #87c6de | <div class="colorChip" style="background: #c2d4dc;"></div> | #c2d4dc | <div class="colorChip" style="background: #e9cbb8;"></div> | #e9cbb8 | <div class="colorChip" style="background: #e6c1c0;"></div> | #e6c1c0 | <div class="colorChip" style="background: #cbbacd;"></div> | #cbbacd |
-| <div class="colorChip" style="background: #a6cddd;"></div> | #a6cddd | <div class="colorChip" style="background: #b3d1dd;"></div> | #b3d1dd | <div class="colorChip" style="background: #eec2a6;"></div> | #eec2a6 | <div class="colorChip" style="background: #e9b4b3;"></div> | #e9b4b3 | <div class="colorChip" style="background: #c3abc6;"></div> | #c3abc6 |
-| <div class="colorChip" style="background: #c2d4dc;"></div> | #c2d4dc | <div class="colorChip" style="background: #a6cddd;"></div> | #a6cddd | <div class="colorChip" style="background: #f2b995;"></div> | #f2b995 | <div class="colorChip" style="background: #eca8a6;"></div> | #eca8a6 | <div class="colorChip" style="background: #ba9bbf;"></div> | #ba9bbf |
-| <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #95c9de;"></div> | #95c9de | <div class="colorChip" style="background: #f5b184;"></div> | #f5b184 | <div class="colorChip" style="background: #ef9999;"></div> | #ef9999 | <div class="colorChip" style="background: #b28cb8;"></div> | #b28cb8 |
-| <div class="colorChip" style="background: #e9cbb8;"></div> | #e9cbb8 | <div class="colorChip" style="background: #87c6de;"></div> | #87c6de | <div class="colorChip" style="background: #f8a972;"></div> | #f8a972 | <div class="colorChip" style="background: #f08d8d;"></div> | #f08d8d | <div class="colorChip" style="background: #aa7bb1;"></div> | #aa7bb1 |
-| <div class="colorChip" style="background: #f2b995;"></div> | #f2b995 | <div class="colorChip" style="background: #73c3df;"></div> | #73c3df | <div class="colorChip" style="background: #faa161;"></div> | #faa161 | <div class="colorChip" style="background: #f17e81;"></div> | #f17e81 | <div class="colorChip" style="background: #a16ca9;"></div> | #a16ca9 |
-| <div class="colorChip" style="background: #f8a972;"></div> | #f8a972 | <div class="colorChip" style="background: #61bfdf;"></div> | #61bfdf | <div class="colorChip" style="background: #fb974f;"></div> | #fb974f | <div class="colorChip" style="background: #f16f75;"></div> | #f16f75 | <div class="colorChip" style="background: #985ca2;"></div> | #985ca2 |
-| <div class="colorChip" style="background: #fb974f;"></div> | #fb974f | <div class="colorChip" style="background: #44bbe0;"></div> | #44bbe0 | <div class="colorChip" style="background: #fc8e3b;"></div> | #fc8e3b | <div class="colorChip" style="background: #f15f68;"></div> | #f15f68 | <div class="colorChip" style="background: #8f4c9b;"></div> | #8f4c9b |
-| <div class="colorChip" style="background: #fc8626;"></div> | #fc8626 | <div class="colorChip" style="background: #16b8e0;"></div> | #16b8e0 | <div class="colorChip" style="background: #fc8626;"></div> | #fc8626 | <div class="colorChip" style="background: #f04d5d;"></div> | #f04d5d | <div class="colorChip" style="background: #853b94;"></div> | #853b94 |
+|                                                            | Diverging |                                                            | Blue    |                                                            | Orange  |                                                            | Red     |                                                            | Purple  |
+| ---------------------------------------------------------- | --------- | ---------------------------------------------------------- | ------- | ---------------------------------------------------------- | ------- | ---------------------------------------------------------- | ------- | ---------------------------------------------------------- | ------- |
+| <div class="colorChip" style="background: #16b8e0;"></div> | #16b8e0   | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb | <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb |
+| <div class="colorChip" style="background: #61bfdf;"></div> | #61bfdf   | <div class="colorChip" style="background: #ced8dc;"></div> | #ced8dc | <div class="colorChip" style="background: #e3d2c9;"></div> | #e3d2c9 | <div class="colorChip" style="background: #e1cfce;"></div> | #e1cfce | <div class="colorChip" style="background: #d3cad4;"></div> | #d3cad4 |
+| <div class="colorChip" style="background: #87c6de;"></div> | #87c6de   | <div class="colorChip" style="background: #c2d4dc;"></div> | #c2d4dc | <div class="colorChip" style="background: #e9cbb8;"></div> | #e9cbb8 | <div class="colorChip" style="background: #e6c1c0;"></div> | #e6c1c0 | <div class="colorChip" style="background: #cbbacd;"></div> | #cbbacd |
+| <div class="colorChip" style="background: #a6cddd;"></div> | #a6cddd   | <div class="colorChip" style="background: #b3d1dd;"></div> | #b3d1dd | <div class="colorChip" style="background: #eec2a6;"></div> | #eec2a6 | <div class="colorChip" style="background: #e9b4b3;"></div> | #e9b4b3 | <div class="colorChip" style="background: #c3abc6;"></div> | #c3abc6 |
+| <div class="colorChip" style="background: #c2d4dc;"></div> | #c2d4dc   | <div class="colorChip" style="background: #a6cddd;"></div> | #a6cddd | <div class="colorChip" style="background: #f2b995;"></div> | #f2b995 | <div class="colorChip" style="background: #eca8a6;"></div> | #eca8a6 | <div class="colorChip" style="background: #ba9bbf;"></div> | #ba9bbf |
+| <div class="colorChip" style="background: #dbdbdb;"></div> | #dbdbdb   | <div class="colorChip" style="background: #95c9de;"></div> | #95c9de | <div class="colorChip" style="background: #f5b184;"></div> | #f5b184 | <div class="colorChip" style="background: #ef9999;"></div> | #ef9999 | <div class="colorChip" style="background: #b28cb8;"></div> | #b28cb8 |
+| <div class="colorChip" style="background: #e9cbb8;"></div> | #e9cbb8   | <div class="colorChip" style="background: #87c6de;"></div> | #87c6de | <div class="colorChip" style="background: #f8a972;"></div> | #f8a972 | <div class="colorChip" style="background: #f08d8d;"></div> | #f08d8d | <div class="colorChip" style="background: #aa7bb1;"></div> | #aa7bb1 |
+| <div class="colorChip" style="background: #f2b995;"></div> | #f2b995   | <div class="colorChip" style="background: #73c3df;"></div> | #73c3df | <div class="colorChip" style="background: #faa161;"></div> | #faa161 | <div class="colorChip" style="background: #f17e81;"></div> | #f17e81 | <div class="colorChip" style="background: #a16ca9;"></div> | #a16ca9 |
+| <div class="colorChip" style="background: #f8a972;"></div> | #f8a972   | <div class="colorChip" style="background: #61bfdf;"></div> | #61bfdf | <div class="colorChip" style="background: #fb974f;"></div> | #fb974f | <div class="colorChip" style="background: #f16f75;"></div> | #f16f75 | <div class="colorChip" style="background: #985ca2;"></div> | #985ca2 |
+| <div class="colorChip" style="background: #fb974f;"></div> | #fb974f   | <div class="colorChip" style="background: #44bbe0;"></div> | #44bbe0 | <div class="colorChip" style="background: #fc8e3b;"></div> | #fc8e3b | <div class="colorChip" style="background: #f15f68;"></div> | #f15f68 | <div class="colorChip" style="background: #8f4c9b;"></div> | #8f4c9b |
+| <div class="colorChip" style="background: #fc8626;"></div> | #fc8626   | <div class="colorChip" style="background: #16b8e0;"></div> | #16b8e0 | <div class="colorChip" style="background: #fc8626;"></div> | #fc8626 | <div class="colorChip" style="background: #f04d5d;"></div> | #f04d5d | <div class="colorChip" style="background: #853b94;"></div> | #853b94 |
 
 <p class="caption">The best color scales align hue and luminosity with their respective numerical value. This requires some corrections for perceptual accuracy. For more background information, see [Picking a Colour Scale for Scientific Graphics](https://betterfigures.org/2015/06/23/picking-a-colour-scale-for-scientific-graphics/) by Doug McNeall. Perceptually accurate, intermediary colors are generated via [Chroma.js](http://gka.github.io/palettes).</p>
 
@@ -83,7 +81,7 @@ This process may seem disjointed, but it allows us to create charts in a consist
 To create clear, understandable, and visually accessible charts, its best to think in layers. In order from bottom to top:
 
 1. **Base layer.** The background color `#EEEEEE`
-2. **Axis grids and text.**  A darker gray `#DBDBDB`
+2. **Axis grids and text.** A darker gray `#DBDBDB`
 3. **Axis labels and zero lines.** Both black; axis text is 25pt bold, zero lines have weight of 3px.
 4. **The data.** Either colored, or light gray.
 5. **Highlighted data.** Emphasized with a stroke of 2px.
@@ -93,7 +91,6 @@ To create clear, understandable, and visually accessible charts, its best to thi
 ![Data viz example 1](/img/guides/data-viz-example-1.png)
 
 <p class="caption">This example contains nearly all of the concepts mentioned above.</p>
-
 
 ---
 
@@ -106,14 +103,15 @@ Below is an evolving list of examples with commentary and links to their respect
 Which axis you put your categorical variables on is an aesthetic choice. In this case, a long list of states is easier to read vertically vs. horizontally. The categorical axis grid is offset to create a table-like effect.
 
 ![Data viz example 2](/img/guides/data-viz-example-2.png)
-<p class="caption">Source: [Announcing nationwide imaging cost estimates on Amino](https://amino.com/blog/announcing-nationwide-imaging-cost-estimates-on-amino/)</p>
 
+<p class="caption">Source: [Announcing nationwide imaging cost estimates on Amino](https://amino.com/blog/announcing-nationwide-imaging-cost-estimates-on-amino/)</p>
 
 ### Time-series data
 
 Line charts are most commonly used to display time-series data. Generally speaking, lines should be used for rate functions, and bars should be used for discrete values.
 
 ![Data viz example 6](/img/guides/data-viz-example-6.png)
+
 <p class="caption">Source: [What data from 205 million private health insurance claims reveals about America’s opioid crisis](https://amino.com/blog/opioid-epidemic-data-opioid-use-disorder/)</p>
 
 The top chart shows deaths per 100,000 residents as a line (rate function) while the bottom chart shows patients as bars (discrete values). This is also an example of a combination chart: one title and two subtitles, tied together with narrative callouts.
@@ -121,6 +119,7 @@ The top chart shows deaths per 100,000 residents as a line (rate function) while
 However, line and bar charts aren't the only way to show how data changes over time. In the example below, a heat map was employed to show when women received a specific type of ultrasound over the course of 308,000 pregnancies. Bands in gray represent weeks where only 100-200 patients were observed as receiving an ultrasound, while the darkest purple bands represent 10,000+ patient observations.
 
 ![Data viz example 3](/img/guides/data-viz-example-3.png)
+
 <p class="caption">Source: [What to expect when you’re expecting pregnancy ultrasounds](https://amino.com/blog/pregnancy-ultrasound-cost-how-many-ultrasounds-during-pregnancy/)</p>
 
 ### Geographical data
@@ -128,17 +127,19 @@ However, line and bar charts aren't the only way to show how data changes over t
 The hexagonal tile map is used when trying to compare states by a scalar variable (like cost, population, or age) and the precise geographical location of each state is not important.
 
 ![Data viz example 5](/img/guides/data-viz-example-5.png)
+
 <p class="caption">Source: [Here’s how much women could pay for preventive care under the AHCA](https://amino.com/blog/heres-how-much-women-could-pay-for-preventive-care-under-the-ahca/)</p>
 
 Regular maps are used to display county-level data or similar levels of detail.
 
 ![Data viz example 7](/img/guides/data-viz-example-7.png)
-<p class="caption">Source: [What data from 205 million private health insurance claims reveals about America’s opioid crisis](https://amino.com/blog/opioid-epidemic-data-opioid-use-disorder/)</p>
 
+<p class="caption">Source: [What data from 205 million private health insurance claims reveals about America’s opioid crisis](https://amino.com/blog/opioid-epidemic-data-opioid-use-disorder/)</p>
 
 ### Relationships
 
 A [chord diagram](https://en.wikipedia.org/wiki/Chord_diagram) is a useful way to visualize relationships in a matrix of data. In this example, the referring doctor is connected to the rendering doctor by a line representing the volume of referrals made that year—the thicker the line, the more referrals. This particular visualization was generated in [Gephi](https://gephi.org/) and imported into Sketch as an SVG.
 
 ![Data viz example 4](/img/guides/data-viz-example-4.png)
+
 <p class="caption">Source: [Data on 211 million referrals shows how doctors really work together](https://amino.com/blog/data-on-211-million-referrals-shows-how-doctors-really-work-together/)</p>

--- a/guides/11-theming.md
+++ b/guides/11-theming.md
@@ -18,7 +18,8 @@ For a good chunk of variables there are two variable declarations, with values f
 
 ```css
 :root {
-  --font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif !default;
+  --font-family: "Sailec", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif !default;
   --text-color-primary: rgba(0, 0, 0, 0.86);
   --text-color-secondary: rgba(0, 0, 0, 0.54);
   --text-color-hint: rgba(0, 0, 0, 0.41);

--- a/library/components/button/README.md
+++ b/library/components/button/README.md
@@ -1,45 +1,44 @@
 For buttons to behave properly on touch devices, make sure you include a touch event handler to the DOM (`document.addEventListener("touchstart", function() {},false);` or `<body ontouchstart="">`). This signals to the browser that there are touch-related CSS styles that need to be applied.
 
-
 ### Props
 
 If a button has an `href` prop, the component renders an achor tag with `role=button`. Otherwise, the button is rendered as a true `button` HTML element.
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | | Class name for the root element. This should include any BEM modifier classes you wish to use.
-| `disabled` | boolean | | If `true`, renders the button in a disabled state and adds an `aria-disabled` attribute for assistive technologies. For true buttons, sets the `disabled` attribute on the element. For anchor-tagged buttons, adds `tabIndex=-1` to prevent user interaction and disables click handling/pointer events.
-| `href` | string | | Determines if the component renders an anchor-tagged button or a true button. If the `href` prop is `'#'`, `event.preventDefault()` is automatically called on click events.
-| `onClick` | function | | Handler for click events. Called with the [SyntheticEvent](https://facebook.github.io/react/docs/events.html) as the only argument.
-| `type` | one of: `'button'`, `'submit'`, `'reset'` | `'button'` | Passed `type` attribute for the `button` element. Ignored by anchor-tagged buttons.
-
+| name        | type                                      | default    | description                                                                                                                                                                                                                                                                                               |
+| ----------- | ----------------------------------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `className` | string                                    |            | Class name for the root element. This should include any BEM modifier classes you wish to use.                                                                                                                                                                                                            |
+| `disabled`  | boolean                                   |            | If `true`, renders the button in a disabled state and adds an `aria-disabled` attribute for assistive technologies. For true buttons, sets the `disabled` attribute on the element. For anchor-tagged buttons, adds `tabIndex=-1` to prevent user interaction and disables click handling/pointer events. |
+| `href`      | string                                    |            | Determines if the component renders an anchor-tagged button or a true button. If the `href` prop is `'#'`, `event.preventDefault()` is automatically called on click events.                                                                                                                              |
+| `onClick`   | function                                  |            | Handler for click events. Called with the [SyntheticEvent](https://facebook.github.io/react/docs/events.html) as the only argument.                                                                                                                                                                       |
+| `type`      | one of: `'button'`, `'submit'`, `'reset'` | `'button'` | Passed `type` attribute for the `button` element. Ignored by anchor-tagged buttons.                                                                                                                                                                                                                       |
 
 Valid HTML attributes and additional event handlers for the `button` or `a` element tags may be safely passed as extra props. Passing a prop that is not a legal DOM attribute will cause React to trigger an [unknown prop warning](https://facebook.github.io/react/warnings/unknown-prop.html). Additionally, you should take care that the props you're passing make sense for the element type being rendered (for example, you should only be passing a `target` or `rel` prop to an anchor-tagged button).
 
-*Note that there are [several attributes that work differently between React and HTML](https://facebook.github.io/react/docs/dom-elements.html). In these cases, attributes should be passed the React-y way.*
-
+_Note that there are [several attributes that work differently between React and HTML](https://facebook.github.io/react/docs/dom-elements.html). In these cases, attributes should be passed the React-y way._
 
 ### Modifiers
 
-| class | default | responsive | notes |
-| ----- | ------- | ---------- | ----- |
-| `Button--small` | false | true | |
-| `Button--medium` | true | true | |
-| `Button--large` | false | true | |
-| `Button--primary` | false | false | |
-| `Button--danger` | false | false | |
-| `Button--link` | false | false | |
+| class             | default | responsive | notes |
+| ----------------- | ------- | ---------- | ----- |
+| `Button--small`   | false   | true       |       |
+| `Button--medium`  | true    | true       |       |
+| `Button--large`   | false   | true       |       |
+| `Button--primary` | false   | false      |       |
+| `Button--danger`  | false   | false      |       |
+| `Button--link`    | false   | false      |       |
 
 ### Usage
 
 Content for the button should be passed as children of the `Button` component:
 
 Javascript:
+
 ```html
-<Button>Click me!</Button>
-<Button href="#">No, click me!</Button>
+<button>Click me!</button> <button href="#">No, click me!</button>
 ```
+
 Rendered markup:
+
 ```html
 <div class="Button">
   <button class="Button__control" type="button">Click me!</button>

--- a/library/components/checkbox/README.md
+++ b/library/components/checkbox/README.md
@@ -6,23 +6,23 @@ The component provides responsive utility classes (see Modifiers below) that can
 
 ### Props
 
-| name | type | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | Class name for the `input` element. This should include any BEM modifier classes you wish to use. |
-| HTML attributes | various | e.g. `checked: true`, `disabled: true`, events, etc. are applied to the `input` |
+| name            | type    | description                                                                                       |
+| --------------- | ------- | ------------------------------------------------------------------------------------------------- |
+| `className`     | string  | Class name for the `input` element. This should include any BEM modifier classes you wish to use. |
+| HTML attributes | various | e.g. `checked: true`, `disabled: true`, events, etc. are applied to the `input`                   |
 
 Valid HTML attributes and event handlers for the input element may be safely passed as additional props. **These props will be applied to the `<input>` element, not the root element of the component.**
 
 Passing a prop that is not a legal DOM attribute will cause React to trigger an [unknown prop warning](https://facebook.github.io/react/warnings/unknown-prop.html).
 
-*Note that there are [several attributes that work differently between React and HTML](https://facebook.github.io/react/docs/dom-elements.html). In these cases, attributes should be passed the React-y way.*
+_Note that there are [several attributes that work differently between React and HTML](https://facebook.github.io/react/docs/dom-elements.html). In these cases, attributes should be passed the React-y way._
 
 ### Modifiers
 
-| class | default | responsive | notes |
-| ----- | ------- | ---------- | ----- |
-| `Checkbox--small[-breakpoint]` | false | true | Responsive breakpoint token optional |
-| `Checkbox--medium[-breakpoint]` | true | true | Responsive breakpoint token optional |
-| `Checkbox--large[-breakpoint]` | false | true | Responsive breakpoint token optional |
+| class                           | default | responsive | notes                                |
+| ------------------------------- | ------- | ---------- | ------------------------------------ |
+| `Checkbox--small[-breakpoint]`  | false   | true       | Responsive breakpoint token optional |
+| `Checkbox--medium[-breakpoint]` | true    | true       | Responsive breakpoint token optional |
+| `Checkbox--large[-breakpoint]`  | false   | true       | Responsive breakpoint token optional |
 
 For the responsive classes, append a responsive breakpoint token to apply the associated sizing styles at that breakpoint and up. For example, `.Checkbox--small .Checkbox--medium-sm .Checkbox--large-md` will give you a small size checkbox on `xs` screens, medium on `sm` screens, and large on `md` screens and up.

--- a/library/components/form_group/README.md
+++ b/library/components/form_group/README.md
@@ -1,21 +1,21 @@
 ### Props
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | | Class name for the root element. This should include any BEM modifier classes you wish to use.
-| `controlId` | string | | The `id` for the `input` element described by the form group's `label` text. See below for notes on `controlId` and accessibility.
-| `label` | string | | Label for form group.
-| `hint` | string | | Helper text for form group.
-| `error` | string | | Error message for form group. If present, form group will be rendered in an error state.
+| name        | type   | default | description                                                                                                                        |
+| ----------- | ------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `className` | string |         | Class name for the root element. This should include any BEM modifier classes you wish to use.                                     |
+| `controlId` | string |         | The `id` for the `input` element described by the form group's `label` text. See below for notes on `controlId` and accessibility. |
+| `label`     | string |         | Label for form group.                                                                                                              |
+| `hint`      | string |         | Helper text for form group.                                                                                                        |
+| `error`     | string |         | Error message for form group. If present, form group will be rendered in an error state.                                           |
 
 ### Modifiers
 
-| class | default | responsive | notes |
-| ----- | ------- | ---------- | ----- |
-| `FormGroup--small` | false | true | |
-| `FormGroup--medium` | true | true | |
-| `FormGroup--large` | false | true | |
-| `FormGroup--has-error` | false | false | If the component has a truthy `error` prop, this modifier is applied automatically. |
+| class                  | default | responsive | notes                                                                               |
+| ---------------------- | ------- | ---------- | ----------------------------------------------------------------------------------- |
+| `FormGroup--small`     | false   | true       |                                                                                     |
+| `FormGroup--medium`    | true    | true       |                                                                                     |
+| `FormGroup--large`     | false   | true       |                                                                                     |
+| `FormGroup--has-error` | false   | false      | If the component has a truthy `error` prop, this modifier is applied automatically. |
 
 ### Usage
 
@@ -24,39 +24,41 @@
 Passing the form group both a `label` and a `controlId` will render a `<label>` element with the `controlId` as its `for` attribute. This pattern should be used for form groups with a visible label and a single text-based input.
 
 Javascript:
+
 ```html
-<FormGroup
-  controlId="dob"
-  label="Birthday"
-  hint="When were you born?"
->
-  <input type="text" id="dob"/>
+<FormGroup controlId="dob" label="Birthday" hint="When were you born?">
+  <input type="text" id="dob" />
 </FormGroup>
 ```
+
 Rendered markup:
+
 ```html
 <div class="FormGroup">
-    <label for="dob" class="FormGroup__label">Birthday</label>
-    <input type="text" id="dob"/>
-    <div class="FormGroup__hint">When were you born?</div>
+  <label for="dob" class="FormGroup__label">Birthday</label>
+  <input type="text" id="dob" />
+  <div class="FormGroup__hint">When were you born?</div>
 </div>
 ```
 
 If the child input has its own label, the `controlId` prop should be omitted.
 
 Javascript:
+
 ```html
 <FormGroup label="Subscribe">
   <label for="subscribe-true">Send me updates</label>
-  <input type="checkbox" value="yes" id="subscribe-true"/>
+  <input type="checkbox" value="yes" id="subscribe-true" />
 </FormGroup>
 ```
+
 Rendered markup:
+
 ```html
 <div class="FormGroup">
-    <label class="FormGroup__label">Subscribe</label>
-    <label for="subscribe-true">Send me updates</label>
-    <input type="checkbox" value="yes" id="subscribe-true"/>
+  <label class="FormGroup__label">Subscribe</label>
+  <label for="subscribe-true">Send me updates</label>
+  <input type="checkbox" value="yes" id="subscribe-true" />
 </div>
 ```
 
@@ -65,17 +67,20 @@ Rendered markup:
 If the form group has multiple inputs, the `controlId` prop can be omitted. In these cases, the child inputs should include an `aria-label` or `aria-labelledby` attribute to ensure accessibility:
 
 Javascript:
+
 ```html
 <FormGroup label="When are you available?">
-  <input type="text" aria-label="Start time"/>
-  <input type="text" aria-label="End time"/>
+  <input type="text" aria-label="Start time" />
+  <input type="text" aria-label="End time" />
 </FormGroup>
 ```
+
 Rendered markup:
+
 ```html
 <div class="FormGroup">
-    <label class="FormGroup__label">When are you available?</label>
-    <input type="text" aria-label="Start time"/>
-    <input type="text" aria-label="End time"/>
+  <label class="FormGroup__label">When are you available?</label>
+  <input type="text" aria-label="Start time" />
+  <input type="text" aria-label="End time" />
 </div>
 ```

--- a/library/components/progress_bar/README.md
+++ b/library/components/progress_bar/README.md
@@ -1,21 +1,24 @@
 ### Props
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | | Class name for the root element.
-| `progress` | number | 0 | Current progress for the bar.
-| `size` | number | | Total number of steps.
-| `stepClassName` | string | `flex-1` | Class name for individual step elements. Default option expands step elements so the root element will fill its container.
+| name            | type   | default  | description                                                                                                                |
+| --------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `className`     | string |          | Class name for the root element.                                                                                           |
+| `progress`      | number | 0        | Current progress for the bar.                                                                                              |
+| `size`          | number |          | Total number of steps.                                                                                                     |
+| `stepClassName` | string | `flex-1` | Class name for individual step elements. Default option expands step elements so the root element will fill its container. |
 
 ### Usage
 
 The width for step elements is configured using the `stepClassName` prop. For example, to render a progress bar with 36px steps, pass `stepClassName="width-6"`.
 
 Javascript:
+
 ```html
-<ProgressBar progress={1} size={3} />
+<ProgressBar progress="{1}" size="{3}" />
 ```
+
 Rendered markup:
+
 ```html
 <ul class="ProgressBar">
   <li class="ProgressBar__step ProgressBar__step--active flex-1"></li>

--- a/library/components/radio/README.md
+++ b/library/components/radio/README.md
@@ -5,19 +5,19 @@ that appears more consistent across platforms.
 
 #### Props
 
-| name | type | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | Class name for the `<label>` container (which has the `.Radio` class). This should include any BEM modifier classes you wish to use. |
-| HTML attributes | various | E.g. `name`, `checked`, `disabled`, events, etc. These are applied to the `input`. |
-| children | node | The children are placed inside of the `.Radio__label` element. |
+| name            | type    | description                                                                                                                          |
+| --------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `className`     | string  | Class name for the `<label>` container (which has the `.Radio` class). This should include any BEM modifier classes you wish to use. |
+| HTML attributes | various | E.g. `name`, `checked`, `disabled`, events, etc. These are applied to the `input`.                                                   |
+| children        | node    | The children are placed inside of the `.Radio__label` element.                                                                       |
 
 #### Sizing Modifiers
 
-| class | default |
-| ----- | ------- |
-| `Radio--small[-breakpoint]` ||
-| `Radio--medium[-breakpoint]` | yes |
-| `Radio--large[-breakpoint]` ||
+| class                        | default |
+| ---------------------------- | ------- |
+| `Radio--small[-breakpoint]`  |         |
+| `Radio--medium[-breakpoint]` | yes     |
+| `Radio--large[-breakpoint]`  |         |
 
 ### RadioGroup
 
@@ -25,18 +25,18 @@ The `RadioGroup` component bundles multiple `Radio` into a single field with one
 
 #### Props
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `name` | string | | The `name` to use on the radio buttons |
-| `value` | string | null | The current selected value of the group |
-| `render` | callback | | Called when rendering the group. Should return the full markup up of the group. See below for details. |
-| `onChange` | callback | | A callback that will be called with the current value every time it changes |
-| `disabled` | boolean | false | Set to true if all of the radio buttons should be disabled |
-| `clearable` | false | Set to true if the user should be able to uncheck a checked radio |
+| name        | type     | default                                                           | description                                                                                            |
+| ----------- | -------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `name`      | string   |                                                                   | The `name` to use on the radio buttons                                                                 |
+| `value`     | string   | null                                                              | The current selected value of the group                                                                |
+| `render`    | callback |                                                                   | Called when rendering the group. Should return the full markup up of the group. See below for details. |
+| `onChange`  | callback |                                                                   | A callback that will be called with the current value every time it changes                            |
+| `disabled`  | boolean  | false                                                             | Set to true if all of the radio buttons should be disabled                                             |
+| `clearable` | false    | Set to true if the user should be able to uncheck a checked radio |
 
 #### `render` prop
 
-The `render` callback should return the full markup of the group, *including* the container element. Using a callback gives you full control over the markup. The callback’s argument is a managed `Radio` component that will automatically behave nicely in the group (e.g. will be checked when its value is selected, will be disabled when the group is disabled, and will automatically update the group's value when the user checks it).
+The `render` callback should return the full markup of the group, _including_ the container element. Using a callback gives you full control over the markup. The callback’s argument is a managed `Radio` component that will automatically behave nicely in the group (e.g. will be checked when its value is selected, will be disabled when the group is disabled, and will automatically update the group's value when the user checks it).
 
 ```
 <RadioGroup value="foo" clearable render={Radio => (

--- a/library/components/slider/README.md
+++ b/library/components/slider/README.md
@@ -12,25 +12,25 @@ The slider is focused when interacting with it (by clicking, touching, or tabbin
 
 #### Props
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | | Class names for the root element (which has the `.Slider` class) |
-| `disabled` | boolean | false | When true, the slider appears disabled and is not interactive |
-| `max` | number | 100 | The highest possible number that `value` can be |
-| `min` | number | 0 | The lowest possible number that `value` can be |
-| `name` | string | | Added to the the hidden `<input>` |
-| `onChange` | callback | | Called when the value changes (the value does change continuously while the slider is dragged) |
-| `onDragEnd` | callback | | Called once when the slider stops dragging |
-| `onDragStart` | callback | | Called once when the slider starts dragging |
-| `required` | boolean | | Added to the hidden `<input>` |
-| `step` | number | 1 | `value` is restricted to increments of this number |
-| `tabIndex` | number | 0 | Applied to the root element so the slider can be focused using the keyboard. Change to -1 to disable that |
-| `value` | number | | Current value (you need to pass this back down when `onChange` is called, so the slider can appear to move) |
-| `...other` | | | All other props (such as `onFocus`) are applied to the root element |
+| name          | type     | default | description                                                                                                 |
+| ------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `className`   | string   |         | Class names for the root element (which has the `.Slider` class)                                            |
+| `disabled`    | boolean  | false   | When true, the slider appears disabled and is not interactive                                               |
+| `max`         | number   | 100     | The highest possible number that `value` can be                                                             |
+| `min`         | number   | 0       | The lowest possible number that `value` can be                                                              |
+| `name`        | string   |         | Added to the the hidden `<input>`                                                                           |
+| `onChange`    | callback |         | Called when the value changes (the value does change continuously while the slider is dragged)              |
+| `onDragEnd`   | callback |         | Called once when the slider stops dragging                                                                  |
+| `onDragStart` | callback |         | Called once when the slider starts dragging                                                                 |
+| `required`    | boolean  |         | Added to the hidden `<input>`                                                                               |
+| `step`        | number   | 1       | `value` is restricted to increments of this number                                                          |
+| `tabIndex`    | number   | 0       | Applied to the root element so the slider can be focused using the keyboard. Change to -1 to disable that   |
+| `value`       | number   |         | Current value (you need to pass this back down when `onChange` is called, so the slider can appear to move) |
+| `...other`    |          |         | All other props (such as `onFocus`) are applied to the root element                                         |
 
 #### Modifiers
 
-| class | notes |
-| ----- | ------- |
+| class                 | notes                                        |
+| --------------------- | -------------------------------------------- |
 | `Slider--is-disabled` | Automatically applied by the react component |
-| `Slider--is-focused` | Automatically applied by the react component |
+| `Slider--is-focused`  | Automatically applied by the react component |

--- a/library/components/switch/README.md
+++ b/library/components/switch/README.md
@@ -2,18 +2,21 @@ The `Switch` component renders a specialized `<input type="checkbox">` that is u
 
 ### Props
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | | Class name for the root element.
-| HTML attributes | various | | e.g. `checked: true`, `disabled: true`, events, etc. are applied to the `input` |
+| name            | type    | default | description                                                                     |
+| --------------- | ------- | ------- | ------------------------------------------------------------------------------- |
+| `className`     | string  |         | Class name for the root element.                                                |
+| HTML attributes | various |         | e.g. `checked: true`, `disabled: true`, events, etc. are applied to the `input` |
 
 ### Usage
 
 Javascript:
+
 ```html
 <Switch checked />
 ```
+
 Rendered markup:
+
 ```html
 <label class="Switch">
   <input class="Switch__input" type="checkbox" checked />

--- a/library/components/tab/README.md
+++ b/library/components/tab/README.md
@@ -1,14 +1,14 @@
 ### Props
 
-| name | type | default | ignored when active | description |
-| ---- | ---- | ------- | ----------- |
-| `active` | boolean | false | | When true, the tab will appear in the active style and be rendered as a span instead of a anchor |
-| `className` | string | | | Additional classes to apply to the Tab for custom styling. The component will automatically apply the `Tab` and `Tab--is-active` classes. |
-| `href` | string | # | yes | For linking the somewhere |
-| `onClick` | callback | | yes | Called when an inactive Tab is clicked. Can be used to change the `active` prop, if desired. |
+| name        | type     | default | ignored when active | description                                                                                                                               |
+| ----------- | -------- | ------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `active`    | boolean  | false   |                     | When true, the tab will appear in the active style and be rendered as a span instead of a anchor                                          |
+| `className` | string   |         |                     | Additional classes to apply to the Tab for custom styling. The component will automatically apply the `Tab` and `Tab--is-active` classes. |
+| `href`      | string   | #       | yes                 | For linking the somewhere                                                                                                                 |
+| `onClick`   | callback |         | yes                 | Called when an inactive Tab is clicked. Can be used to change the `active` prop, if desired.                                              |
 
 ### Modifiers
 
-| class | default | responsive | notes |
-| ----- | ------- | ---------- | ----- |
-| `Tab--is-active` | false | false | The React component will apply this automatically when the `active` prop is true. |
+| class            | default | responsive | notes                                                                             |
+| ---------------- | ------- | ---------- | --------------------------------------------------------------------------------- |
+| `Tab--is-active` | false   | false      | The React component will apply this automatically when the `active` prop is true. |

--- a/library/components/text_input/README.md
+++ b/library/components/text_input/README.md
@@ -1,37 +1,38 @@
 ### Props
 
-| name | type | default | description |
-| ---- | ---- | ------- | ----------- |
-| `className` | string | | Class name for the `input` element. This should include any BEM modifier classes you wish to use. |
-| `type` | valid HTML `type` for text-based `input` element | 'text' | |
+| name        | type                                             | default | description                                                                                       |
+| ----------- | ------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------- |
+| `className` | string                                           |         | Class name for the `input` element. This should include any BEM modifier classes you wish to use. |
+| `type`      | valid HTML `type` for text-based `input` element | 'text'  |                                                                                                   |
 
 The `type` prop must be one of the the allowed input types:
+
 ```javascript
-color
-date
-datetime
-datetime-local
-email
-month
-number
-password
-search
-tel
-text
-time
-url
-week
+color;
+date;
+datetime;
+datetime - local;
+email;
+month;
+number;
+password;
+search;
+tel;
+text;
+time;
+url;
+week;
 ```
 
 Valid HTML attributes and event handlers for the input element may be safely passed as additional props. Passing a prop that is not a legal DOM attribute will cause React to trigger an [unknown prop warning](https://facebook.github.io/react/warnings/unknown-prop.html).
 
-*Note that there are [several attributes that work differently between React and HTML](https://facebook.github.io/react/docs/dom-elements.html). In these cases, attributes should be passed the React-y way.*
+_Note that there are [several attributes that work differently between React and HTML](https://facebook.github.io/react/docs/dom-elements.html). In these cases, attributes should be passed the React-y way._
 
 ### Modifiers
 
-| class | default | responsive | notes |
-| ----- | ------- | ---------- | ----- |
-| `TextInput--small` | false | true | |
-| `TextInput--medium` | true | true | |
-| `TextInput--large` | false | true | |
-| `TextInput--has-error` | false | false | |
+| class                  | default | responsive | notes |
+| ---------------------- | ------- | ---------- | ----- |
+| `TextInput--small`     | false   | true       |       |
+| `TextInput--medium`    | true    | true       |       |
+| `TextInput--large`     | false   | true       |       |
+| `TextInput--has-error` | false   | false      |       |

--- a/library/utilities/display/README.md
+++ b/library/utilities/display/README.md
@@ -1,4 +1,4 @@
-Responsive display utility classes allow you to quickly set an element's `display` property to any valid value. The format is: 
+Responsive display utility classes allow you to quickly set an element's `display` property to any valid value. The format is:
 
 ```
 .d-[value]-[breakpoint]
@@ -6,14 +6,14 @@ Responsive display utility classes allow you to quickly set an element's `displa
 
 Above, `value` is one of:
 
-* `none`
-* `inline`
-* `inline-block`
-* `block`
-* `table`
-* `table-cell`
-* `flex`
-* `inline-flex`
+- `none`
+- `inline`
+- `inline-block`
+- `block`
+- `table`
+- `table-cell`
+- `flex`
+- `inline-flex`
 
 The `breakpoint` suffix specifies the minimum screen size to apply the rule. For example, `.d-none.d-block-md` would hide the element at `xs` and `sm` sizes and show it at `md` and up.
 
@@ -23,5 +23,5 @@ Adapted from Bootstrap 4.
 
 Related:
 
-* [Bootstrap display utilities](https://v4-alpha.getbootstrap.com/utilities/display-property/)
-* [Responsive breakpoints](/docs/layout/#responsive-breakpoints)
+- [Bootstrap display utilities](https://v4-alpha.getbootstrap.com/utilities/display-property/)
+- [Responsive breakpoints](/docs/layout/#responsive-breakpoints)

--- a/library/utilities/flexbox/README.md
+++ b/library/utilities/flexbox/README.md
@@ -14,6 +14,6 @@ Adapted from Bootstrap 4.
 
 Related:
 
-* [Bootstrap 4 flexbox utilities](https://v4-alpha.getbootstrap.com/utilities/flexbox/)
-* [A Complete Guide to Flexbox on CSS-Tricks](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
-* [Responsive breakpoints](/docs/layout/#responsive-breakpoints)
+- [Bootstrap 4 flexbox utilities](https://v4-alpha.getbootstrap.com/utilities/flexbox/)
+- [A Complete Guide to Flexbox on CSS-Tricks](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+- [Responsive breakpoints](/docs/layout/#responsive-breakpoints)

--- a/library/utilities/sizing/README.md
+++ b/library/utilities/sizing/README.md
@@ -10,17 +10,17 @@ Note: for percentage width layouts, see the [the grid system](/components/detail
 .height-[size][-breakpoint]
 ```
 
-* `size` is a modular scale number from 0 to 9, or "full" for 100%.
-* `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
+- `size` is a modular scale number from 0 to 9, or "full" for 100%.
+- `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
 
 Examples:
 
-* `.width-5`
-* `.width-full`
-* `.height-3.height-full-xl`
+- `.width-5`
+- `.width-full`
+- `.height-3.height-full-xl`
 
 Related:
 
-* [Modular Scale](/docs/modular-scale/)
-* [Spacing](/docs/spacing/)
-* [Responsive breakpoints](/docs/layout/#responsive-breakpoints)
+- [Modular Scale](/docs/modular-scale/)
+- [Spacing](/docs/spacing/)
+- [Responsive breakpoints](/docs/layout/#responsive-breakpoints)

--- a/library/utilities/spacing/README.md
+++ b/library/utilities/spacing/README.md
@@ -8,40 +8,37 @@ Responsive class utilities are provided for as well, following this format:
 .[property][sides][size]-[breakpoint]
 ```
 
-* `property` is `m` or `p` for margin or padding, respectively
-* `sides` (optional) is one of:
-	* `t`, `b`, `l`, or `r` for top/bottom/left/right
-	* `x` or `y` for horizontal/vertical
-	* omitted for all sides
-* `size` is a number from 0 to 9 (corresponding to the variables above)
-* `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
+- `property` is `m` or `p` for margin or padding, respectively
+- `sides` (optional) is one of:
+  _ `t`, `b`, `l`, or `r` for top/bottom/left/right
+  _ `x` or `y` for horizontal/vertical \* omitted for all sides
+- `size` is a number from 0 to 9 (corresponding to the variables above)
+- `breakpoint` is an optional responsive breakpoint (`sm`, `md`, `lg`, `xl`)
 
 Special cases:
 
-* Margin auto values follow the pattern `.m[x,y]-auto-[breakpoint]`
-* Negative spacing helpers for x-axis: `.mxn[size]-[breakpoint]`
+- Margin auto values follow the pattern `.m[x,y]-auto-[breakpoint]`
+- Negative spacing helpers for x-axis: `.mxn[size]-[breakpoint]`
 
 Examples:
 
-* `.mb4.mb5-md` adds 16px `margin-bottom` for `xs` up, and 24px for `md` up
-* `.py1` adds 5px `padding-top` and `padding-bottom`
-
+- `.mb4.mb5-md` adds 16px `margin-bottom` for `xs` up, and 24px for `md` up
+- `.py1` adds 5px `padding-top` and `padding-bottom`
 
 ### SASS variables
 
 | SASS variable | Space |
-| -------- | ----- |
-| `$spacer-0` | 0 |
-| `$spacer-1` | 5px |
-| `$spacer-2` | 7px |
-| `$spacer-3` | 11px |
-| `$spacer-4` | 16px |
-| `$spacer-5` | 24px |
-| `$spacer-6` | 36px |
-| `$spacer-7` | 53px |
-| `$spacer-8` | 79px |
-| `$spacer-9` | 119px |
-
+| ------------- | ----- |
+| `$spacer-0`   | 0     |
+| `$spacer-1`   | 5px   |
+| `$spacer-2`   | 7px   |
+| `$spacer-3`   | 11px  |
+| `$spacer-4`   | 16px  |
+| `$spacer-5`   | 24px  |
+| `$spacer-6`   | 36px  |
+| `$spacer-7`   | 53px  |
+| `$spacer-8`   | 79px  |
+| `$spacer-9`   | 119px |
 
 ### Etc.
 
@@ -51,7 +48,7 @@ Adapted from Bootstrap 4.
 
 Related:
 
-* [Modular Scale](/docs/modular-scale/)
-* [Spacing](/docs/spacing/)
-* [Responsive breakpoints](/docs/layout/#responsive-breakpoints)
-* [Bootstrap 4 spacing utilities](https://v4-alpha.getbootstrap.com/utilities/spacing/)
+- [Modular Scale](/docs/modular-scale/)
+- [Spacing](/docs/spacing/)
+- [Responsive breakpoints](/docs/layout/#responsive-breakpoints)
+- [Bootstrap 4 spacing utilities](https://v4-alpha.getbootstrap.com/utilities/spacing/)

--- a/library/utilities/typography/README.md
+++ b/library/utilities/typography/README.md
@@ -14,5 +14,5 @@ Note: this feature is enabled by default and adds 344 lines of CSS (approx 10kb)
 
 Related:
 
-* [Typography](/docs/typography/)
-* [Responsive breakpoints](/docs/layout/#responsive-breakpoints)
+- [Typography](/docs/typography/)
+- [Responsive breakpoints](/docs/layout/#responsive-breakpoints)


### PR DESCRIPTION
A recent update caused some of the markdown tables to be broken when rendered in the phenotypes documentation website. Reformatting the markdown files with prettier fixes the issue, so I went ahead and applied prettier formatting to all of the relevant markdown files. After testing locally, all markdown files seem to be rendered correctly.