### PR TITLE
add aria to associate error with form

### DIFF
--- a/library/components/form_group/form_group.jsx
+++ b/library/components/form_group/form_group.jsx
@@ -27,7 +27,7 @@ class FormGroup extends React.Component {
     return (
       errorBoolean && (
         <div
-          id="formErrorMessage"
+          id={this.props.controlId}
           className="FormGroup__error"
           aria-live={errorBoolean ? 'assertive' : 'off'} // A live region scenario is when an error message is displayed to users only after they have provided invalid information
         >
@@ -53,7 +53,7 @@ class FormGroup extends React.Component {
         className={classes(this.props.className, 'FormGroup', {
           'FormGroup--has-error': errorBoolean,
         })}
-        aria-errormessage="formErrorMessage"
+        aria-errormessage={this.props.controlId}
         aria-invalid={errorBoolean ? 'true' : 'false'}
       >
         {this.renderLabel()}

--- a/library/components/form_group/form_group.jsx
+++ b/library/components/form_group/form_group.jsx
@@ -27,7 +27,7 @@ class FormGroup extends React.Component {
     return (
       errorBoolean && (
         <div
-          id={this.props.controlId}
+          id={this.props.errorId}
           className="FormGroup__error"
           aria-live={errorBoolean ? 'assertive' : 'off'} // A live region scenario is when an error message is displayed to users only after they have provided invalid information
         >
@@ -53,8 +53,6 @@ class FormGroup extends React.Component {
         className={classes(this.props.className, 'FormGroup', {
           'FormGroup--has-error': errorBoolean,
         })}
-        aria-errormessage={this.props.controlId}
-        aria-invalid={errorBoolean ? 'true' : 'false'}
       >
         {this.renderLabel()}
         {this.renderChildren()}

--- a/library/components/form_group/form_group.jsx
+++ b/library/components/form_group/form_group.jsx
@@ -23,9 +23,16 @@ class FormGroup extends React.Component {
   }
 
   renderError() {
+    const errorBoolean = !!this.props.error;
     return (
-      !!this.props.error && (
-        <div className="FormGroup__error">{this.props.error}</div>
+      errorBoolean && (
+        <div
+          id="formErrorMessage"
+          className="FormGroup__error"
+          aria-live={errorBoolean ? 'assertive' : 'off'} // A live region scenario is when an error message is displayed to users only after they have provided invalid information
+        >
+          {this.props.error}
+        </div>
       )
     );
   }
@@ -40,11 +47,14 @@ class FormGroup extends React.Component {
   }
 
   render() {
+    const errorBoolean = !!this.props.error;
     return (
       <div
         className={classes(this.props.className, 'FormGroup', {
-          'FormGroup--has-error': !!this.props.error,
+          'FormGroup--has-error': errorBoolean,
         })}
+        aria-errormessage="formErrorMessage"
+        aria-invalid={errorBoolean ? 'true' : 'false'}
       >
         {this.renderLabel()}
         {this.renderChildren()}

--- a/library/components/form_group/form_group.jsx
+++ b/library/components/form_group/form_group.jsx
@@ -23,13 +23,13 @@ class FormGroup extends React.Component {
   }
 
   renderError() {
-    const errorBoolean = !!this.props.error;
+    const hasError = !!this.props.error;
     return (
-      errorBoolean && (
+      hasError && (
         <div
           id={this.props.errorId}
           className="FormGroup__error"
-          aria-live={errorBoolean ? 'assertive' : 'off'} // A live region scenario is when an error message is displayed to users only after they have provided invalid information
+          aria-live="assertive" // A live region scenario is when an error message is displayed to users only after they have provided invalid information
         >
           {this.props.error}
         </div>
@@ -47,11 +47,11 @@ class FormGroup extends React.Component {
   }
 
   render() {
-    const errorBoolean = !!this.props.error;
+    const hasError = !!this.props.error;
     return (
       <div
         className={classes(this.props.className, 'FormGroup', {
-          'FormGroup--has-error': errorBoolean,
+          'FormGroup--has-error': hasError,
         })}
       >
         {this.renderLabel()}


### PR DESCRIPTION
Fix accessibility issues related to error messages
```
The error messages on forms show visibly but are not programmatically associated with the text field potentially causing users to not understand how to complete the forms. 
```

this shows how the `aria-errormessage` is getting the proper id:
![Screen Shot 2021-05-06 at 2 35 32 PM](https://user-images.githubusercontent.com/39747784/117355736-ce3e8380-ae67-11eb-8688-66d459929045.png)

screen reader alerting "required" once the `save` button is clicked:
![Screen Recording 2021-05-07 at 10 28 11 AM](https://user-images.githubusercontent.com/39747784/117473405-ca197100-af0e-11eb-9d89-1b640aea972c.gif)

more info on `aria-errormessage: [https://www.w3.org/TR/wai-aria-1.1/#aria-errormessage](https://www.w3.org/TR/wai-aria-1.1/#aria-errormessage)
