### PR TITLE
Border sizing fix for buttons

### DIFF
--- a/fractal_assets/css/phenotypes.themable.css
+++ b/fractal_assets/css/phenotypes.themable.css
@@ -489,11 +489,12 @@ hr {
 
 .Button--danger .Button__control {
   background: var(--danger-button-color);
-  border: 0;
+  border: 1px solid var(--danger-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
     background: var(--danger-button-focus-color);
+    border: 1px solid var(--danger-button-focus-color);
     color: #fff; }
 
 .Button--danger .Button__control:active,
@@ -503,12 +504,13 @@ hr {
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   background: var(--primary-button-color);
-  border: 0;
+  border: 1px solid var(--primary-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
     background: var(--primary-button-focus-color);
+    border: 1px solid var(--primary-button-focus-color);
     color: #fff; }
 
 .Button--primary .Button__control:active,

--- a/library/components/button/_button.scss
+++ b/library/components/button/_button.scss
@@ -88,13 +88,14 @@
 .Button--danger {
   .Button__control {
     background: var(--danger-button-color);
-    border: 0;
+    border: 1px solid var(--danger-button-color);
     color: $white;
     font-weight: $font-weight-bold;
 
     &:hover,
     &:focus {
       background: var(--danger-button-focus-color);
+      border: 1px solid var(--danger-button-focus-color);
       color: $white;
     }
   }
@@ -112,7 +113,7 @@
   .Button__control {
     @include depth(4);
     background: var(--primary-button-color);
-    border: 0;
+    border: 1px solid var(--primary-button-color);
     color: $white;
     font-weight: $font-weight-bold;
 
@@ -120,6 +121,7 @@
     &:focus {
       @include depth(7);
       background: var(--primary-button-focus-color);
+      border: 1px solid var(--primary-button-focus-color);
       color: $white;
     }
   }

--- a/styles/phenotypes.css
+++ b/styles/phenotypes.css
@@ -432,11 +432,12 @@ hr {
 
 .Button--danger .Button__control {
   background: rgb(171, 0, 43);
-  border: 0;
+  border: 1px solid rgb(171, 0, 43);
   color: #fff;
   font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
     background: #78001e;
+    border: 1px solid #78001e;
     color: #fff; }
 
 .Button--danger .Button__control:active,
@@ -446,12 +447,13 @@ hr {
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   background: rgb(0, 94, 176);
-  border: 0;
+  border: 1px solid rgb(0, 94, 176);
   color: #fff;
   font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
     background: #002b66;
+    border: 1px solid #002b66;
     color: #fff; }
 
 .Button--primary .Button__control:active,

--- a/styles/phenotypes.themable.css
+++ b/styles/phenotypes.themable.css
@@ -489,11 +489,12 @@ hr {
 
 .Button--danger .Button__control {
   background: var(--danger-button-color);
-  border: 0;
+  border: 1px solid var(--danger-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--danger .Button__control:hover, .Button--danger .Button__control:focus {
     background: var(--danger-button-focus-color);
+    border: 1px solid var(--danger-button-focus-color);
     color: #fff; }
 
 .Button--danger .Button__control:active,
@@ -503,12 +504,13 @@ hr {
 .Button--primary .Button__control {
   box-shadow: 0 3px 6px rgba(0, 0, 0, 0.14), 0 1px 1px rgba(0, 0, 0, 0.07), 0 0 6px rgba(0, 0, 0, 0.07);
   background: var(--primary-button-color);
-  border: 0;
+  border: 1px solid var(--primary-button-color);
   color: #fff;
   font-weight: bold; }
   .Button--primary .Button__control:hover, .Button--primary .Button__control:focus {
     box-shadow: 0 5px 10px rgba(0, 0, 0, 0.14), 0 1px 2px rgba(0, 0, 0, 0.07), 0 0 10px rgba(0, 0, 0, 0.07);
     background: var(--primary-button-focus-color);
+    border: 1px solid var(--primary-button-focus-color);
     color: #fff; }
 
 .Button--primary .Button__control:active,


### PR DESCRIPTION
Updates the primary color and error color buttons to have a 1px border of the same color, to keep the height the same as the already bordered secondary buttons