### PR TITLE
Bump to version 11.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aminohealth/phenotypes",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "Amino's design language and front-end component library",
   "dependencies": {
     "@babel/runtime": "^7.10.2",


### PR DESCRIPTION
Pushing out the node-sass -> sass conversion so that anything that uses phenotypes isn't blocked from working with apple silicon.

This also adds a few dependency security patches added by @dependabot.