### PR TITLE
Simple nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,22 @@ FROM node:14.4.0-stretch-slim
 
 ENV NPM_CONFIG_LOGLEVEL warn
 
+ENV APP /usr/src/app
+
 # Create app directory
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
+RUN mkdir -p $APP
+WORKDIR $APP
 
 # Install app dependencies
-COPY ./package.json /usr/src/app/
-COPY ./yarn.lock /usr/src/app/
+COPY ./package.json $APP
+COPY ./yarn.lock $APP
 RUN yarn install
 
 # Bundle app source
-COPY . /usr/src/app
+COPY . $APP
+
+WORKDIR $APP
+
+RUN npm run buildStatic
+
+VOLUME $APP

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,4 +1,4 @@
-FROM nginx:1.21.1
+FROM nginx:1.21
 
 ENV STATICDIR /usr/src/app/static-build
 ENV HTMLDIR /usr/share/nginx/html

--- a/Dockerfile-nginx
+++ b/Dockerfile-nginx
@@ -1,0 +1,8 @@
+FROM nginx:1.21.1
+
+ENV STATICDIR /usr/src/app/static-build
+ENV HTMLDIR /usr/share/nginx/html
+
+RUN rm -rf $HTMLDIR && \
+    mkdir -p $STATICDIR && \
+    ln -s $STATICDIR $HTMLDIR

--- a/amino_build.json
+++ b/amino_build.json
@@ -2,13 +2,15 @@
     "app": "phenotypes",
     "build": {
         "components": ["phenotypes"],
-        "services": ["fractal"]
+        "services": ["fractal", "nginx"]
     },
     "deploy": {
         "preview": {
-            "cluster": "services-preview",
-            "region": "us-west-1",
-            "service": "phenotypes"
+            "cluster": "preprod-dmz",
+            "region": "us-west-2",
+            "service": "preview-phenotypes",
+            "profile": "aminotf",
+            "registry": "043538302950.dkr.ecr.us-west-2.amazonaws.com"
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,11 @@ services:
     volumes:
       - .:/usr/src/app
       - /usr/src/app/node_modules
+  nginx:
+    build:
+      context: .
+      dockerfile: Dockerfile-nginx
+    ports:
+      - '3001:80'
+    volumes_from:
+      - fractal


### PR DESCRIPTION
@ewdicus cribbing off of how we do it in the web, here's a proof of concept for putting nginx in front of fractal. It involves:

* Building the static site as part of the base docker build
* Mapping volumes between the fractal container + the nginx container
* Symlinking the static output folder to be where nginx by default looks for static html files

With this you should be able to `make build run` + visit http://localhost:3001 to see how nginx renders the static site.

Am I missing anything that would pose issues to this approach?